### PR TITLE
feat: add reminder system with MCP tools and scheduler

### DIFF
--- a/bot/src/claudeClient.ts
+++ b/bot/src/claudeClient.ts
@@ -1,5 +1,13 @@
 import { spawn } from 'node:child_process';
+import path from 'node:path';
 import type { ChatMessage, LLMResponse } from './types';
+
+export interface MessageContext {
+  groupId: string;
+  sender: string;
+  dbPath: string;
+  timezone: string;
+}
 
 interface ClaudeResultLine {
   type: 'result';
@@ -11,7 +19,9 @@ interface ClaudeResultLine {
   };
 }
 
-const ALLOWED_TOOLS = 'WebSearch,WebFetch,Read,Glob,Grep';
+const BASE_TOOLS = 'WebSearch,WebFetch,Read,Glob,Grep';
+const MCP_TOOLS = 'mcp__reminders__set_reminder,mcp__reminders__list_reminders,mcp__reminders__cancel_reminder';
+const ALLOWED_TOOLS = `${BASE_TOOLS},${MCP_TOOLS}`;
 
 function spawnPromise(
   cmd: string,
@@ -67,7 +77,7 @@ export class ClaudeCLIClient {
     this.maxTurns = maxTurns;
   }
 
-  async generateResponse(messages: ChatMessage[]): Promise<LLMResponse> {
+  async generateResponse(messages: ChatMessage[], context?: MessageContext): Promise<LLMResponse> {
     if (!messages || messages.length === 0) {
       throw new Error('Messages array cannot be empty');
     }
@@ -95,6 +105,25 @@ export class ClaudeCLIClient {
       '--allowedTools',
       ALLOWED_TOOLS,
     ];
+
+    if (context) {
+      const mcpServerPath = path.resolve(__dirname, 'reminderMcpServer.js');
+      const mcpConfig = JSON.stringify({
+        mcpServers: {
+          reminders: {
+            command: 'node',
+            args: [mcpServerPath],
+            env: {
+              DB_PATH: context.dbPath,
+              MCP_GROUP_ID: context.groupId,
+              MCP_SENDER: context.sender,
+              TZ: context.timezone,
+            },
+          },
+        },
+      });
+      args.push('--mcp-config', mcpConfig, '--strict-mcp-config');
+    }
 
     if (systemPrompt) {
       args.push('--system-prompt', systemPrompt);

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -10,6 +10,7 @@ export interface ConfigType {
   signalCliUrl: string;
   dbPath: string;
   systemPrompt: string;
+  timezone: string;
 }
 
 const DEFAULT_SYSTEM_PROMPT =
@@ -54,6 +55,7 @@ export class Config {
       signalCliUrl: process.env.SIGNAL_CLI_URL || 'http://localhost:8080',
       dbPath: process.env.DB_PATH || './data/bot.db',
       systemPrompt: process.env.SYSTEM_PROMPT || DEFAULT_SYSTEM_PROMPT,
+      timezone: process.env.BOT_TIMEZONE || 'Australia/Sydney',
     };
   }
 }

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,6 +1,7 @@
 import { ClaudeCLIClient } from './claudeClient';
 import { Config } from './config';
 import { MessageHandler } from './messageHandler';
+import { ReminderScheduler } from './reminderScheduler';
 import { SignalClient } from './signalClient';
 import { Storage } from './storage';
 
@@ -19,6 +20,9 @@ async function main() {
   const signalClient = new SignalClient(config.signalCliUrl, config.botPhoneNumber);
   console.log('Signal client initialized');
 
+  const reminderScheduler = new ReminderScheduler(storage, signalClient);
+  console.log('Reminder scheduler initialized');
+
   const messageHandler = new MessageHandler(config.mentionTriggers, {
     botPhoneNumber: config.botPhoneNumber,
     systemPrompt: config.systemPrompt,
@@ -26,6 +30,8 @@ async function main() {
     llmClient,
     signalClient,
     contextWindowSize: config.contextWindowSize,
+    timezone: config.timezone,
+    dbPath: config.dbPath,
   });
   console.log(`Message handler initialized (triggers: ${config.mentionTriggers.join(', ')})`);
 
@@ -44,6 +50,9 @@ async function main() {
 
   // Start polling loop
   console.log('Starting message polling...');
+  const REMINDER_CHECK_INTERVAL = 15;
+  let tickCount = 0;
+
   while (true) {
     try {
       const messages = await signalClient.receiveMessages();
@@ -54,6 +63,17 @@ async function main() {
         if (data) {
           console.log(`[${data.groupId}] ${data.sender}: ${data.content.substring(0, 50)}...`);
           await messageHandler.handleMessage(data.groupId, data.sender, data.content, data.timestamp);
+        }
+      }
+
+      // Check for due reminders periodically
+      tickCount++;
+      if (tickCount >= REMINDER_CHECK_INTERVAL) {
+        tickCount = 0;
+        try {
+          await reminderScheduler.processDueReminders();
+        } catch (error) {
+          console.error('Error processing reminders:', error);
         }
       }
     } catch (error) {

--- a/bot/src/messageHandler.ts
+++ b/bot/src/messageHandler.ts
@@ -12,6 +12,8 @@ export class MessageHandler {
   private llmClient?: ClaudeCLIClient;
   private signalClient?: SignalClient;
   private contextWindowSize: number;
+  private timezone: string;
+  private dbPath: string;
   private processedMessages: Set<string> = new Set();
 
   constructor(
@@ -23,6 +25,8 @@ export class MessageHandler {
       llmClient?: ClaudeCLIClient;
       signalClient?: SignalClient;
       contextWindowSize?: number;
+      timezone?: string;
+      dbPath?: string;
     },
   ) {
     this.mentionTriggers = mentionTriggers;
@@ -33,6 +37,8 @@ export class MessageHandler {
     this.llmClient = options?.llmClient;
     this.signalClient = options?.signalClient;
     this.contextWindowSize = options?.contextWindowSize || 20;
+    this.timezone = options?.timezone || 'Australia/Sydney';
+    this.dbPath = options?.dbPath || './data/bot.db';
   }
 
   isMentioned(content: string): boolean {
@@ -57,8 +63,39 @@ export class MessageHandler {
     return query.replace(/\s+/g, ' ').trim();
   }
 
-  buildContext(history: Message[], currentQuery: string): ChatMessage[] {
-    const contextMessages: ChatMessage[] = [{ role: 'system', content: this.systemPrompt }];
+  buildContext(history: Message[], currentQuery: string, groupId?: string, sender?: string): ChatMessage[] {
+    let systemContent = this.systemPrompt;
+
+    if (groupId && sender) {
+      const now = new Date();
+      // Build a proper ISO 8601 string with timezone offset
+      const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: this.timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+        timeZoneName: 'shortOffset',
+      }).formatToParts(now);
+      const get = (type: string) => parts.find(p => p.type === type)?.value || '';
+      const offset = get('timeZoneName').replace('GMT', '') || '+00:00';
+      const isoString = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}${offset}`;
+      const unixMs = now.getTime();
+
+      const timeContext = [
+        `Current time: ${isoString} (Unix ms: ${unixMs})`,
+        `Timezone: ${this.timezone}`,
+        `Group ID: ${groupId}`,
+        `Current requester: ${sender}`,
+      ].join('\n');
+
+      systemContent = `${timeContext}\n\n${systemContent}`;
+    }
+
+    const contextMessages: ChatMessage[] = [{ role: 'system', content: systemContent }];
 
     for (const msg of history) {
       if (msg.isBot) {
@@ -130,10 +167,15 @@ export class MessageHandler {
       const query = this.extractQuery(content);
 
       // Build context
-      const messages = this.buildContext(history, query);
+      const messages = this.buildContext(history, query, groupId, sender);
 
       // Get LLM response
-      const response = await this.llmClient.generateResponse(messages);
+      const response = await this.llmClient.generateResponse(messages, {
+        groupId,
+        sender,
+        dbPath: this.dbPath,
+        timezone: this.timezone,
+      });
 
       // Send response
       await this.signalClient.sendMessage(groupId, response.content);

--- a/bot/src/reminderMcpServer.ts
+++ b/bot/src/reminderMcpServer.ts
@@ -1,0 +1,222 @@
+import * as readline from 'node:readline';
+import { Storage } from './storage';
+
+const PROTOCOL_VERSION = '2025-03-26';
+
+const dbPath = process.env.DB_PATH || './data/bot.db';
+const groupId = process.env.MCP_GROUP_ID || '';
+const sender = process.env.MCP_SENDER || '';
+
+let storage: Storage;
+
+const TOOLS = [
+  {
+    name: 'set_reminder',
+    title: 'Set Reminder',
+    description:
+      'Set a reminder that will be delivered to this Signal group chat at the specified time. Parse natural language time into a Unix millisecond timestamp before calling.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        reminderText: { type: 'string', description: 'The reminder message to deliver' },
+        dueAt: {
+          type: 'number',
+          description: 'When to deliver the reminder, as a Unix timestamp in milliseconds',
+        },
+      },
+      required: ['reminderText', 'dueAt'],
+    },
+  },
+  {
+    name: 'list_reminders',
+    title: 'List Reminders',
+    description: 'List all pending reminders for this Signal group chat.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+    },
+  },
+  {
+    name: 'cancel_reminder',
+    title: 'Cancel Reminder',
+    description: 'Cancel a pending reminder by its ID.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        reminderId: { type: 'number', description: 'The ID of the reminder to cancel' },
+      },
+      required: ['reminderId'],
+    },
+  },
+];
+
+function handleSetReminder(args: Record<string, unknown>): {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+} {
+  const reminderText = args.reminderText as string;
+  const dueAt = args.dueAt as number;
+
+  if (!reminderText || typeof reminderText !== 'string') {
+    return { content: [{ type: 'text', text: 'Missing or invalid reminderText parameter.' }], isError: true };
+  }
+  if (!dueAt || typeof dueAt !== 'number') {
+    return { content: [{ type: 'text', text: 'Missing or invalid dueAt parameter.' }], isError: true };
+  }
+  if (dueAt <= Date.now()) {
+    return { content: [{ type: 'text', text: 'The reminder time must be in the future.' }], isError: true };
+  }
+  if (!groupId) {
+    return { content: [{ type: 'text', text: 'No group context available.' }], isError: true };
+  }
+
+  try {
+    const id = storage.createReminder(groupId, sender, reminderText, dueAt);
+    const dueDate = new Date(dueAt);
+    const formatted = dueDate.toLocaleString('en-AU', { timeZone: process.env.TZ || 'Australia/Sydney' });
+    return { content: [{ type: 'text', text: `Reminder #${id} set for ${formatted}: "${reminderText}"` }] };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    return { content: [{ type: 'text', text: `Failed to set reminder: ${msg}` }], isError: true };
+  }
+}
+
+function handleListReminders(): { content: Array<{ type: string; text: string }> } {
+  if (!groupId) {
+    return { content: [{ type: 'text', text: 'No group context available.' }] };
+  }
+
+  const reminders = storage.listReminders(groupId);
+  if (reminders.length === 0) {
+    return { content: [{ type: 'text', text: 'No pending reminders for this group.' }] };
+  }
+
+  const tz = process.env.TZ || 'Australia/Sydney';
+  const lines = reminders.map(r => {
+    const due = new Date(r.dueAt).toLocaleString('en-AU', { timeZone: tz });
+    return `#${r.id} | Due: ${due} | "${r.reminderText}" (set by ${r.requester})`;
+  });
+  return { content: [{ type: 'text', text: `Pending reminders:\n${lines.join('\n')}` }] };
+}
+
+function handleCancelReminder(args: Record<string, unknown>): {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+} {
+  const reminderId = args.reminderId as number;
+
+  if (!reminderId || typeof reminderId !== 'number') {
+    return { content: [{ type: 'text', text: 'Missing or invalid reminderId parameter.' }], isError: true };
+  }
+  if (!groupId) {
+    return { content: [{ type: 'text', text: 'No group context available.' }], isError: true };
+  }
+
+  const success = storage.cancelReminder(reminderId, groupId);
+  if (success) {
+    return { content: [{ type: 'text', text: `Reminder #${reminderId} has been cancelled.` }] };
+  }
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Could not cancel reminder #${reminderId}. It may not exist, belong to a different group, or already be sent/cancelled.`,
+      },
+    ],
+  };
+}
+
+function handleToolCall(
+  name: string,
+  args: Record<string, unknown>,
+): { content: Array<{ type: string; text: string }>; isError?: boolean } {
+  switch (name) {
+    case 'set_reminder':
+      return handleSetReminder(args);
+    case 'list_reminders':
+      return handleListReminders();
+    case 'cancel_reminder':
+      return handleCancelReminder(args);
+    default:
+      return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+  }
+}
+
+function handleMessage(msg: { id?: number | string; method: string; params?: Record<string, unknown> }): object | null {
+  const { id, method, params } = msg;
+
+  switch (method) {
+    case 'initialize':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: 'signal-bot-reminders', version: '1.0.0' },
+        },
+      };
+
+    case 'notifications/initialized':
+      // Notification — no response
+      return null;
+
+    case 'tools/list':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: { tools: TOOLS },
+      };
+
+    case 'tools/call': {
+      const toolName = (params?.name as string) || '';
+      const toolArgs = (params?.arguments as Record<string, unknown>) || {};
+      const result = handleToolCall(toolName, toolArgs);
+      return { jsonrpc: '2.0', id, result };
+    }
+
+    default:
+      // Unknown method
+      if (id !== undefined) {
+        return {
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32601, message: `Method not found: ${method}` },
+        };
+      }
+      // Unknown notification — ignore
+      return null;
+  }
+}
+
+function main() {
+  storage = new Storage(dbPath);
+  console.error(`Reminder MCP server started (group: ${groupId || 'none'}, sender: ${sender || 'none'})`);
+
+  const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+  rl.on('line', (line: string) => {
+    if (!line.trim()) return;
+
+    try {
+      const msg = JSON.parse(line);
+      const response = handleMessage(msg);
+      if (response) {
+        process.stdout.write(`${JSON.stringify(response)}\n`);
+      }
+    } catch (error) {
+      console.error('Error processing message:', error);
+      // Send parse error
+      process.stdout.write(
+        `${JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } })}\n`,
+      );
+    }
+  });
+
+  rl.on('close', () => {
+    storage.close();
+    process.exit(0);
+  });
+}
+
+main();

--- a/bot/src/reminderScheduler.ts
+++ b/bot/src/reminderScheduler.ts
@@ -1,0 +1,84 @@
+import type { SignalClient } from './signalClient';
+import type { Storage } from './storage';
+import type { Reminder } from './types';
+
+const MAX_RETRIES = 3;
+const MAX_STALENESS_MS = 24 * 60 * 60 * 1000; // 24 hours
+const BATCH_LIMIT = 50;
+
+export class ReminderScheduler {
+  private storage: Storage;
+  private signalClient: SignalClient;
+
+  constructor(storage: Storage, signalClient: SignalClient) {
+    this.storage = storage;
+    this.signalClient = signalClient;
+  }
+
+  async processDueReminders(): Promise<number> {
+    const now = Date.now();
+    const reminders = this.storage.getDueReminders(now, BATCH_LIMIT);
+    let sentCount = 0;
+
+    for (const reminder of reminders) {
+      const success = await this.processReminder(reminder, now);
+      if (success) {
+        sentCount++;
+      }
+    }
+
+    if (sentCount > 0) {
+      console.log(`Processed ${sentCount} reminder(s)`);
+    }
+
+    return sentCount;
+  }
+
+  private async processReminder(reminder: Reminder, now: number): Promise<boolean> {
+    const staleness = now - reminder.dueAt;
+
+    // If >24h overdue, mark failed (stale)
+    if (staleness > MAX_STALENESS_MS) {
+      console.warn(`Reminder ${reminder.id} is ${Math.round(staleness / 3600000)}h overdue, marking as failed`);
+      this.storage.markReminderFailed(reminder.id);
+      return false;
+    }
+
+    // If retryCount >= MAX_RETRIES, mark failed
+    if (reminder.retryCount >= MAX_RETRIES) {
+      console.warn(`Reminder ${reminder.id} exceeded max retries (${MAX_RETRIES}), marking as failed`);
+      this.storage.markReminderFailed(reminder.id);
+      return false;
+    }
+
+    // Format message
+    const messageText = this.formatReminderMessage(reminder, staleness);
+
+    try {
+      await this.signalClient.sendMessage(reminder.groupId, messageText);
+      this.storage.markReminderSent(reminder.id);
+      return true;
+    } catch (error) {
+      console.error(`Failed to send reminder ${reminder.id}:`, error);
+      this.storage.incrementReminderRetry(reminder.id);
+      return false;
+    }
+  }
+
+  private formatReminderMessage(reminder: Reminder, stalenessMs: number): string {
+    let message = `\u23F0 Reminder: ${reminder.reminderText}`;
+
+    // If significantly late (>5 min), add note
+    if (stalenessMs > 5 * 60 * 1000) {
+      const minutesLate = Math.round(stalenessMs / 60000);
+      if (minutesLate < 60) {
+        message += `\n(${minutesLate} minutes late)`;
+      } else {
+        const hoursLate = Math.round(minutesLate / 60);
+        message += `\n(${hoursLate} hour${hoursLate > 1 ? 's' : ''} late)`;
+      }
+    }
+
+    return message;
+  }
+}

--- a/bot/src/storage.ts
+++ b/bot/src/storage.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import type { Message } from './types';
+import type { Message, Reminder, ReminderStatus } from './types';
 
 function wrapSqliteError(error: unknown, operation: string): never {
   if (error instanceof Error) {
@@ -22,11 +22,19 @@ export class Storage {
     insert: Database.Statement;
     selectRecent: Database.Statement;
     trim: Database.Statement;
+    insertReminder: Database.Statement;
+    selectDueReminders: Database.Statement;
+    markReminderSent: Database.Statement;
+    markReminderFailed: Database.Statement;
+    incrementReminderRetry: Database.Statement;
+    cancelReminder: Database.Statement;
+    listReminders: Database.Statement;
   };
 
   constructor(dbPath: string) {
     try {
       this.db = new Database(dbPath);
+      this.db.pragma('journal_mode = WAL');
       this.initTables();
       this.stmts = {
         insert: this.db.prepare(`
@@ -48,6 +56,33 @@ export class Storage {
             ORDER BY timestamp DESC
             LIMIT ?
           )
+        `),
+        insertReminder: this.db.prepare(`
+          INSERT INTO reminders (groupId, requester, reminderText, dueAt, status, retryCount, createdAt)
+          VALUES (?, ?, ?, ?, 'pending', 0, ?)
+        `),
+        selectDueReminders: this.db.prepare(`
+          SELECT * FROM reminders
+          WHERE status = 'pending' AND dueAt <= ?
+          ORDER BY dueAt ASC
+          LIMIT ?
+        `),
+        markReminderSent: this.db.prepare(`
+          UPDATE reminders SET status = 'sent', sentAt = ? WHERE id = ? AND status = 'pending'
+        `),
+        markReminderFailed: this.db.prepare(`
+          UPDATE reminders SET status = 'failed' WHERE id = ? AND status = 'pending'
+        `),
+        incrementReminderRetry: this.db.prepare(`
+          UPDATE reminders SET retryCount = retryCount + 1 WHERE id = ?
+        `),
+        cancelReminder: this.db.prepare(`
+          UPDATE reminders SET status = 'cancelled' WHERE id = ? AND groupId = ? AND status = 'pending'
+        `),
+        listReminders: this.db.prepare(`
+          SELECT * FROM reminders
+          WHERE groupId = ? AND status = 'pending'
+          ORDER BY dueAt ASC
         `),
       };
     } catch (error) {
@@ -72,6 +107,24 @@ export class Storage {
 
         CREATE INDEX IF NOT EXISTS idx_group_timestamp
         ON messages(groupId, timestamp DESC);
+
+        CREATE TABLE IF NOT EXISTS reminders (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          groupId TEXT NOT NULL,
+          requester TEXT NOT NULL,
+          reminderText TEXT NOT NULL,
+          dueAt INTEGER NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          retryCount INTEGER NOT NULL DEFAULT 0,
+          createdAt INTEGER NOT NULL,
+          sentAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_reminders_due
+        ON reminders(status, dueAt);
+
+        CREATE INDEX IF NOT EXISTS idx_reminders_group
+        ON reminders(groupId, status);
       `);
     } catch (error) {
       wrapSqliteError(error, 'create tables');
@@ -144,10 +197,124 @@ export class Storage {
     }
   }
 
+  createReminder(groupId: string, requester: string, reminderText: string, dueAt: number): number {
+    this.ensureOpen();
+    if (!groupId || groupId.trim() === '') {
+      throw new Error('Invalid groupId: cannot be empty');
+    }
+    if (!reminderText || reminderText.trim() === '') {
+      throw new Error('Invalid reminderText: cannot be empty');
+    }
+    if (dueAt <= Date.now()) {
+      throw new Error('Invalid dueAt: must be in the future');
+    }
+
+    try {
+      const result = this.stmts.insertReminder.run(groupId, requester, reminderText, dueAt, Date.now());
+      return Number(result.lastInsertRowid);
+    } catch (error) {
+      wrapSqliteError(error, 'create reminder');
+    }
+  }
+
+  getDueReminders(now?: number, limit: number = 50): Reminder[] {
+    this.ensureOpen();
+
+    try {
+      const rows = this.stmts.selectDueReminders.all(now ?? Date.now(), limit) as Array<ReminderRow>;
+      return rows.map(mapReminderRow);
+    } catch (error) {
+      wrapSqliteError(error, 'get due reminders');
+    }
+  }
+
+  markReminderSent(id: number): boolean {
+    this.ensureOpen();
+
+    try {
+      const result = this.stmts.markReminderSent.run(Date.now(), id);
+      return result.changes > 0;
+    } catch (error) {
+      wrapSqliteError(error, 'mark reminder sent');
+    }
+  }
+
+  markReminderFailed(id: number): boolean {
+    this.ensureOpen();
+
+    try {
+      const result = this.stmts.markReminderFailed.run(id);
+      return result.changes > 0;
+    } catch (error) {
+      wrapSqliteError(error, 'mark reminder failed');
+    }
+  }
+
+  incrementReminderRetry(id: number): void {
+    this.ensureOpen();
+
+    try {
+      this.stmts.incrementReminderRetry.run(id);
+    } catch (error) {
+      wrapSqliteError(error, 'increment reminder retry');
+    }
+  }
+
+  cancelReminder(id: number, groupId: string): boolean {
+    this.ensureOpen();
+
+    try {
+      const result = this.stmts.cancelReminder.run(id, groupId);
+      return result.changes > 0;
+    } catch (error) {
+      wrapSqliteError(error, 'cancel reminder');
+    }
+  }
+
+  listReminders(groupId: string): Reminder[] {
+    this.ensureOpen();
+    if (!groupId || groupId.trim() === '') {
+      throw new Error('Invalid groupId: cannot be empty');
+    }
+
+    try {
+      const rows = this.stmts.listReminders.all(groupId) as Array<ReminderRow>;
+      return rows.map(mapReminderRow);
+    } catch (error) {
+      wrapSqliteError(error, 'list reminders');
+    }
+  }
+
   close(): void {
     if (!this.closed) {
       this.db.close();
       this.closed = true;
     }
   }
+}
+
+interface ReminderRow {
+  id: number;
+  groupId: string;
+  requester: string;
+  reminderText: string;
+  dueAt: number;
+  status: string;
+  retryCount: number;
+  createdAt: number;
+  sentAt: number | null;
+}
+
+function mapReminderRow(row: ReminderRow): Reminder {
+  return {
+    id: row.id,
+    groupId: row.groupId,
+    requester: row.requester,
+    reminderText: row.reminderText,
+    dueAt: row.dueAt,
+    status: row.status as ReminderStatus,
+    retryCount: row.retryCount,
+    createdAt: row.createdAt,
+    sentAt: row.sentAt,
+  };
 }

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -17,6 +17,20 @@ export interface LLMResponse {
   tokensUsed: number;
 }
 
+export type ReminderStatus = 'pending' | 'sent' | 'cancelled' | 'failed';
+
+export interface Reminder {
+  id: number;
+  groupId: string;
+  requester: string;
+  reminderText: string;
+  dueAt: number;
+  status: ReminderStatus;
+  retryCount: number;
+  createdAt: number;
+  sentAt: number | null;
+}
+
 export interface SignalMessage {
   envelope: {
     source?: string;

--- a/bot/tests/claudeClient.test.ts
+++ b/bot/tests/claudeClient.test.ts
@@ -248,6 +248,45 @@ describe('ClaudeCLIClient', () => {
       expect(args[maxTurnsIdx]).toBe('3');
     });
 
+    it('should include MCP config when context is provided', async () => {
+      mockSpawnSuccess(makeResultOutput('Reminder set!'));
+
+      const client = new ClaudeCLIClient();
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Remind me' }];
+      const context = {
+        groupId: 'test-group',
+        sender: '+61400000000',
+        dbPath: '/tmp/test.db',
+        timezone: 'Australia/Sydney',
+      };
+
+      await client.generateResponse(messages, context);
+
+      const args = mockSpawn.mock.calls[0][1];
+      expect(args).toContain('--mcp-config');
+      expect(args).toContain('--strict-mcp-config');
+
+      const mcpConfigIdx = args.indexOf('--mcp-config') + 1;
+      const mcpConfig = JSON.parse(args[mcpConfigIdx]);
+      expect(mcpConfig.mcpServers.reminders).toBeDefined();
+      expect(mcpConfig.mcpServers.reminders.command).toBe('node');
+      expect(mcpConfig.mcpServers.reminders.env.MCP_GROUP_ID).toBe('test-group');
+      expect(mcpConfig.mcpServers.reminders.env.MCP_SENDER).toBe('+61400000000');
+      expect(mcpConfig.mcpServers.reminders.env.DB_PATH).toBe('/tmp/test.db');
+      expect(mcpConfig.mcpServers.reminders.env.TZ).toBe('Australia/Sydney');
+    });
+
+    it('should not include MCP config when context is not provided', async () => {
+      mockSpawnSuccess(makeResultOutput('Hello!'));
+
+      const client = new ClaudeCLIClient();
+      await client.generateResponse([{ role: 'user', content: 'Hi' }]);
+
+      const args = mockSpawn.mock.calls[0][1];
+      expect(args).not.toContain('--mcp-config');
+      expect(args).not.toContain('--strict-mcp-config');
+    });
+
     it('should parse JSON array output format', async () => {
       const output = JSON.stringify([
         { type: 'system', subtype: 'init', session_id: 'test' },

--- a/bot/tests/messageHandler.test.ts
+++ b/bot/tests/messageHandler.test.ts
@@ -338,6 +338,11 @@ describe('MessageHandler', () => {
           expect.objectContaining({ role: 'user', content: 'Alice: Previous message' }),
           expect.objectContaining({ role: 'user', content: 'what is 2+2?' }),
         ]),
+        expect.objectContaining({
+          groupId: 'g1',
+          sender: 'Bob',
+          timezone: 'Australia/Sydney',
+        }),
       );
     });
 

--- a/bot/tests/reminderMcpServer.test.ts
+++ b/bot/tests/reminderMcpServer.test.ts
@@ -1,0 +1,242 @@
+// We test the MCP server by importing its handler logic indirectly through the storage layer,
+// and by spawning it as a child process to test the full stdio protocol.
+import { type ChildProcess, spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('Reminder MCP Server', () => {
+  let testDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'mcp-server-test-'));
+    dbPath = join(testDir, 'test.db');
+  });
+
+  afterEach(() => {
+    if (testDir) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  function spawnMcpServer(env: Record<string, string> = {}): ChildProcess {
+    return spawn('npx', ['tsx', join(__dirname, '../src/reminderMcpServer.ts')], {
+      env: {
+        ...process.env,
+        DB_PATH: dbPath,
+        MCP_GROUP_ID: 'test-group-1',
+        MCP_SENDER: '+61400000000',
+        TZ: 'Australia/Sydney',
+        ...env,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+
+  async function sendAndReceive(proc: ChildProcess, message: object): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout waiting for MCP response')), 10000);
+      const handler = (data: Buffer) => {
+        const line = data.toString().trim();
+        if (!line) return;
+        try {
+          const response = JSON.parse(line);
+          clearTimeout(timeout);
+          proc.stdout.removeListener('data', handler);
+          resolve(response);
+        } catch {
+          // partial data, wait for more
+        }
+      };
+      proc.stdout.on('data', handler);
+      proc.stdin.write(`${JSON.stringify(message)}\n`);
+    });
+  }
+
+  async function initializeServer(proc: ChildProcess): Promise<void> {
+    await sendAndReceive(proc, {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } },
+    });
+    // Send initialized notification (no response expected)
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`);
+  }
+
+  it('should respond to initialize request', async () => {
+    const proc = spawnMcpServer();
+    try {
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } },
+      });
+
+      expect(response.jsonrpc).toBe('2.0');
+      expect(response.id).toBe(1);
+      const result = response.result as Record<string, unknown>;
+      expect(result.capabilities).toEqual({ tools: {} });
+      const serverInfo = result.serverInfo as Record<string, string>;
+      expect(serverInfo.name).toBe('signal-bot-reminders');
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it('should list 3 tools', async () => {
+    const proc = spawnMcpServer();
+    try {
+      await initializeServer(proc);
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+      });
+
+      const result = response.result as { tools: Array<{ name: string }> };
+      expect(result.tools).toHaveLength(3);
+      expect(result.tools.map(t => t.name)).toEqual(['set_reminder', 'list_reminders', 'cancel_reminder']);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it('should set a reminder via tools/call', async () => {
+    const proc = spawnMcpServer();
+    try {
+      await initializeServer(proc);
+      const dueAt = Date.now() + 3600000; // 1 hour from now
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'set_reminder',
+          arguments: { reminderText: 'Doctor appointment', dueAt },
+        },
+      });
+
+      const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Reminder #1');
+      expect(result.content[0].text).toContain('Doctor appointment');
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it('should list reminders after setting one', async () => {
+    const proc = spawnMcpServer();
+    try {
+      await initializeServer(proc);
+      const dueAt = Date.now() + 3600000;
+
+      // Set a reminder
+      await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'set_reminder', arguments: { reminderText: 'Buy groceries', dueAt } },
+      });
+
+      // Now call list_reminders tool
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'list_reminders', arguments: {} },
+      });
+
+      const result = response.result as { content: Array<{ text: string }> };
+      expect(result.content[0].text).toContain('Buy groceries');
+      expect(result.content[0].text).toContain('#1');
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it('should cancel a reminder', async () => {
+    const proc = spawnMcpServer();
+    try {
+      await initializeServer(proc);
+      const dueAt = Date.now() + 3600000;
+
+      // Set a reminder
+      await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'set_reminder', arguments: { reminderText: 'Cancel me', dueAt } },
+      });
+
+      // Cancel it
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'cancel_reminder', arguments: { reminderId: 1 } },
+      });
+
+      const result = response.result as { content: Array<{ text: string }> };
+      expect(result.content[0].text).toContain('cancelled');
+
+      // Verify list is empty
+      const listResponse = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'list_reminders', arguments: {} },
+      });
+
+      const listResult = listResponse.result as { content: Array<{ text: string }> };
+      expect(listResult.content[0].text).toContain('No pending reminders');
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it('should reject past due dates', async () => {
+    const proc = spawnMcpServer();
+    try {
+      await initializeServer(proc);
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'set_reminder',
+          arguments: { reminderText: 'Too late', dueAt: Date.now() - 60000 },
+        },
+      });
+
+      const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('future');
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it('should return error for unknown tool', async () => {
+    const proc = spawnMcpServer();
+    try {
+      await initializeServer(proc);
+      const response = await sendAndReceive(proc, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'nonexistent_tool', arguments: {} },
+      });
+
+      const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Unknown tool');
+    } finally {
+      proc.kill();
+    }
+  });
+});

--- a/bot/tests/reminderScheduler.test.ts
+++ b/bot/tests/reminderScheduler.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReminderScheduler } from '../src/reminderScheduler';
+import type { Reminder } from '../src/types';
+
+function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
+  return {
+    id: 1,
+    groupId: 'group1',
+    requester: '+61400000000',
+    reminderText: 'Test reminder',
+    dueAt: Date.now() - 1000, // just past due
+    status: 'pending',
+    retryCount: 0,
+    createdAt: Date.now() - 60000,
+    sentAt: null,
+    ...overrides,
+  };
+}
+
+describe('ReminderScheduler', () => {
+  let mockStorage: {
+    getDueReminders: ReturnType<typeof vi.fn>;
+    markReminderSent: ReturnType<typeof vi.fn>;
+    markReminderFailed: ReturnType<typeof vi.fn>;
+    incrementReminderRetry: ReturnType<typeof vi.fn>;
+  };
+  let mockSignalClient: {
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+  let scheduler: ReminderScheduler;
+
+  beforeEach(() => {
+    mockStorage = {
+      getDueReminders: vi.fn().mockReturnValue([]),
+      markReminderSent: vi.fn(),
+      markReminderFailed: vi.fn(),
+      incrementReminderRetry: vi.fn(),
+    };
+    mockSignalClient = {
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    scheduler = new ReminderScheduler(mockStorage as any, mockSignalClient as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('processDueReminders', () => {
+    it('should return 0 when no due reminders exist', async () => {
+      mockStorage.getDueReminders.mockReturnValue([]);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(0);
+      expect(mockSignalClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should send a single reminder successfully and return 1', async () => {
+      const reminder = makeReminder();
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(1);
+      expect(mockSignalClient.sendMessage).toHaveBeenCalledTimes(1);
+      expect(mockSignalClient.sendMessage).toHaveBeenCalledWith('group1', expect.stringContaining('Test reminder'));
+      expect(mockStorage.markReminderSent).toHaveBeenCalledWith(1);
+    });
+
+    it('should process multiple reminders and return correct count', async () => {
+      const reminders = [
+        makeReminder({ id: 1, reminderText: 'First' }),
+        makeReminder({ id: 2, reminderText: 'Second' }),
+        makeReminder({ id: 3, reminderText: 'Third' }),
+      ];
+      mockStorage.getDueReminders.mockReturnValue(reminders);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(3);
+      expect(mockSignalClient.sendMessage).toHaveBeenCalledTimes(3);
+      expect(mockStorage.markReminderSent).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return 0 when send fails on first attempt', async () => {
+      const reminder = makeReminder();
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+      mockSignalClient.sendMessage.mockRejectedValue(new Error('Network error'));
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(0);
+      expect(mockStorage.incrementReminderRetry).toHaveBeenCalledWith(1);
+      expect(mockStorage.markReminderSent).not.toHaveBeenCalled();
+    });
+
+    it('should mark reminder as failed when retryCount >= MAX_RETRIES', async () => {
+      const reminder = makeReminder({ retryCount: 3 });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(0);
+      expect(mockStorage.markReminderFailed).toHaveBeenCalledWith(1);
+      expect(mockSignalClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should mark stale reminder (>24h overdue) as failed', async () => {
+      const now = Date.now();
+      const twentyFiveHoursAgo = now - 25 * 60 * 60 * 1000;
+      const reminder = makeReminder({ dueAt: twentyFiveHoursAgo });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(0);
+      expect(mockStorage.markReminderFailed).toHaveBeenCalledWith(1);
+      expect(mockSignalClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should handle mixed batch with some successes and some failures', async () => {
+      const reminders = [
+        makeReminder({ id: 1, reminderText: 'Success 1' }),
+        makeReminder({ id: 2, reminderText: 'Fail', retryCount: 3 }), // max retries
+        makeReminder({ id: 3, reminderText: 'Success 2' }),
+      ];
+      mockStorage.getDueReminders.mockReturnValue(reminders);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(2);
+      expect(mockSignalClient.sendMessage).toHaveBeenCalledTimes(2);
+      expect(mockStorage.markReminderSent).toHaveBeenCalledTimes(2);
+      expect(mockStorage.markReminderFailed).toHaveBeenCalledWith(2);
+    });
+
+    it('should log when reminders are processed', async () => {
+      const reminder = makeReminder();
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      expect(console.log).toHaveBeenCalledWith('Processed 1 reminder(s)');
+    });
+
+    it('should not log when no reminders are processed', async () => {
+      mockStorage.getDueReminders.mockReturnValue([]);
+
+      await scheduler.processDueReminders();
+
+      expect(console.log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('message formatting', () => {
+    it('should start with reminder emoji and contain reminder text', async () => {
+      const reminder = makeReminder({ reminderText: 'Buy groceries' });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      const sentMessage = mockSignalClient.sendMessage.mock.calls[0][1];
+      expect(sentMessage).toMatch(/^⏰ Reminder: Buy groceries/);
+    });
+
+    it('should not include lateness annotation for on-time reminders', async () => {
+      const reminder = makeReminder({ dueAt: Date.now() - 1000 }); // 1 second ago
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      const sentMessage = mockSignalClient.sendMessage.mock.calls[0][1];
+      expect(sentMessage).toBe('\u23F0 Reminder: Test reminder');
+      expect(sentMessage).not.toContain('late');
+    });
+
+    it('should include minutes late annotation for 5-60 minute delay', async () => {
+      const now = Date.now();
+      const tenMinutesAgo = now - 10 * 60 * 1000;
+      const reminder = makeReminder({ dueAt: tenMinutesAgo });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      const sentMessage = mockSignalClient.sendMessage.mock.calls[0][1];
+      expect(sentMessage).toContain('(10 minutes late)');
+    });
+
+    it('should include hours late annotation for 1-24h delay', async () => {
+      const now = Date.now();
+      const threeHoursAgo = now - 3 * 60 * 60 * 1000;
+      const reminder = makeReminder({ dueAt: threeHoursAgo });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      const sentMessage = mockSignalClient.sendMessage.mock.calls[0][1];
+      expect(sentMessage).toContain('(3 hours late)');
+    });
+
+    it('should use singular "hour" for 1 hour late', async () => {
+      const now = Date.now();
+      const oneHourAgo = now - 60 * 60 * 1000;
+      const reminder = makeReminder({ dueAt: oneHourAgo });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      const sentMessage = mockSignalClient.sendMessage.mock.calls[0][1];
+      expect(sentMessage).toContain('(1 hour late)');
+      expect(sentMessage).not.toContain('hours');
+    });
+
+    it('should not include lateness for exactly 5 minutes', async () => {
+      const now = Date.now();
+      const fiveMinutesAgo = now - 5 * 60 * 1000;
+      const reminder = makeReminder({ dueAt: fiveMinutesAgo });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      const sentMessage = mockSignalClient.sendMessage.mock.calls[0][1];
+      expect(sentMessage).not.toContain('late');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should increment retry on send failure without marking as failed', async () => {
+      const reminder = makeReminder({ retryCount: 1 });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+      mockSignalClient.sendMessage.mockRejectedValue(new Error('Connection refused'));
+
+      await scheduler.processDueReminders();
+
+      expect(mockStorage.incrementReminderRetry).toHaveBeenCalledWith(1);
+      expect(mockStorage.markReminderFailed).not.toHaveBeenCalled();
+      expect(mockStorage.markReminderSent).not.toHaveBeenCalled();
+    });
+
+    it('should log error on send failure', async () => {
+      const reminder = makeReminder();
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+      const error = new Error('Connection refused');
+      mockSignalClient.sendMessage.mockRejectedValue(error);
+
+      await scheduler.processDueReminders();
+
+      expect(console.error).toHaveBeenCalledWith('Failed to send reminder 1:', error);
+    });
+
+    it('should warn when marking stale reminder as failed', async () => {
+      const now = Date.now();
+      const reminder = makeReminder({ dueAt: now - 25 * 60 * 60 * 1000 });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('overdue, marking as failed'));
+    });
+
+    it('should warn when marking max-retry reminder as failed', async () => {
+      const reminder = makeReminder({ retryCount: 3 });
+      mockStorage.getDueReminders.mockReturnValue([reminder]);
+
+      await scheduler.processDueReminders();
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('exceeded max retries'));
+    });
+
+    it('should continue processing remaining reminders after one fails to send', async () => {
+      const reminders = [
+        makeReminder({ id: 1, reminderText: 'Fails' }),
+        makeReminder({ id: 2, reminderText: 'Succeeds' }),
+      ];
+      mockStorage.getDueReminders.mockReturnValue(reminders);
+      mockSignalClient.sendMessage.mockRejectedValueOnce(new Error('Failed')).mockResolvedValueOnce(undefined);
+
+      const count = await scheduler.processDueReminders();
+
+      expect(count).toBe(1);
+      expect(mockStorage.incrementReminderRetry).toHaveBeenCalledWith(1);
+      expect(mockStorage.markReminderSent).toHaveBeenCalledWith(2);
+    });
+  });
+});

--- a/bot/tests/storage.reminders.test.ts
+++ b/bot/tests/storage.reminders.test.ts
@@ -1,0 +1,317 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Storage } from '../src/storage';
+
+describe('Storage - Reminders', () => {
+  let testDir: string;
+  let storage: Storage;
+
+  const createStorage = () => {
+    testDir = mkdtempSync(join(tmpdir(), 'signal-bot-reminder-test-'));
+    storage = new Storage(join(testDir, 'test.db'));
+    return storage;
+  };
+
+  afterEach(() => {
+    storage?.close();
+    if (testDir) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('createReminder', () => {
+    it('should create a reminder and return its ID', () => {
+      createStorage();
+      const futureTime = Date.now() + 60000;
+      const id = storage.createReminder('group1', '+61400000000', 'Buy milk', futureTime);
+      expect(id).toBe(1);
+    });
+
+    it('should create multiple reminders with incrementing IDs', () => {
+      createStorage();
+      const futureTime = Date.now() + 60000;
+      const id1 = storage.createReminder('group1', '+61400000000', 'Task 1', futureTime);
+      const id2 = storage.createReminder('group1', '+61400000000', 'Task 2', futureTime + 1000);
+      expect(id2).toBe(id1 + 1);
+    });
+
+    it('should reject empty groupId', () => {
+      createStorage();
+      expect(() => storage.createReminder('', '+61400000000', 'Test', Date.now() + 60000)).toThrow(
+        'Invalid groupId: cannot be empty',
+      );
+    });
+
+    it('should reject empty reminderText', () => {
+      createStorage();
+      expect(() => storage.createReminder('group1', '+61400000000', '', Date.now() + 60000)).toThrow(
+        'Invalid reminderText: cannot be empty',
+      );
+    });
+
+    it('should reject past dueAt', () => {
+      createStorage();
+      expect(() => storage.createReminder('group1', '+61400000000', 'Test', Date.now() - 1000)).toThrow(
+        'Invalid dueAt: must be in the future',
+      );
+    });
+  });
+
+  describe('getDueReminders', () => {
+    it('should return empty array when no reminders exist', () => {
+      createStorage();
+      const reminders = storage.getDueReminders(Date.now());
+      expect(reminders).toEqual([]);
+    });
+
+    it('should return only pending reminders where dueAt <= now', () => {
+      createStorage();
+      const now = Date.now();
+      // Use vi.spyOn to allow creating reminders with "past" timestamps
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      storage.createReminder('group1', 'Alice', 'Due reminder', now - 60000);
+      storage.createReminder('group1', 'Alice', 'Future reminder', now + 60000);
+      vi.restoreAllMocks();
+
+      const reminders = storage.getDueReminders(now);
+      expect(reminders).toHaveLength(1);
+      expect(reminders[0].reminderText).toBe('Due reminder');
+      expect(reminders[0].status).toBe('pending');
+    });
+
+    it('should not return sent reminders', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      storage.markReminderSent(id);
+      const reminders = storage.getDueReminders(now);
+      expect(reminders).toHaveLength(0);
+    });
+
+    it('should not return failed reminders', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      storage.markReminderFailed(id);
+      const reminders = storage.getDueReminders(now);
+      expect(reminders).toHaveLength(0);
+    });
+
+    it('should respect the limit parameter', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      for (let i = 0; i < 5; i++) {
+        storage.createReminder('group1', 'Alice', `Reminder ${i}`, now - 60000 + i);
+      }
+      vi.restoreAllMocks();
+
+      const reminders = storage.getDueReminders(now, 3);
+      expect(reminders).toHaveLength(3);
+    });
+
+    it('should return results ordered by dueAt ASC', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 200000);
+      storage.createReminder('group1', 'Alice', 'Later', now - 30000);
+      storage.createReminder('group1', 'Alice', 'Earlier', now - 60000);
+      vi.restoreAllMocks();
+
+      const reminders = storage.getDueReminders(now);
+      expect(reminders[0].reminderText).toBe('Earlier');
+      expect(reminders[1].reminderText).toBe('Later');
+    });
+  });
+
+  describe('markReminderSent', () => {
+    it('should mark a pending reminder as sent', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      const result = storage.markReminderSent(id);
+      expect(result).toBe(true);
+
+      // Verify it's no longer in due reminders
+      const reminders = storage.getDueReminders(now);
+      expect(reminders).toHaveLength(0);
+    });
+
+    it('should return false for already-sent reminders', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      storage.markReminderSent(id);
+      const result = storage.markReminderSent(id);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent ID', () => {
+      createStorage();
+      const result = storage.markReminderSent(999);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('markReminderFailed', () => {
+    it('should mark a pending reminder as failed', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      const result = storage.markReminderFailed(id);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-pending reminders', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      storage.markReminderSent(id);
+      const result = storage.markReminderFailed(id);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('incrementReminderRetry', () => {
+    it('should increment the retry count', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      storage.incrementReminderRetry(id);
+      storage.incrementReminderRetry(id);
+
+      const reminders = storage.getDueReminders(now);
+      expect(reminders[0].retryCount).toBe(2);
+    });
+  });
+
+  describe('cancelReminder', () => {
+    it('should cancel a pending reminder', () => {
+      createStorage();
+      const id = storage.createReminder('group1', 'Alice', 'Test', Date.now() + 60000);
+      const result = storage.cancelReminder(id, 'group1');
+      expect(result).toBe(true);
+    });
+
+    it('should not cancel a reminder from a different group', () => {
+      createStorage();
+      const id = storage.createReminder('group1', 'Alice', 'Test', Date.now() + 60000);
+      const result = storage.cancelReminder(id, 'group2');
+      expect(result).toBe(false);
+    });
+
+    it('should not cancel an already-sent reminder', () => {
+      createStorage();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      storage.markReminderSent(id);
+      const result = storage.cancelReminder(id, 'group1');
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent ID', () => {
+      createStorage();
+      const result = storage.cancelReminder(999, 'group1');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('listReminders', () => {
+    it('should list pending reminders for a group', () => {
+      createStorage();
+      const futureTime = Date.now() + 60000;
+      storage.createReminder('group1', 'Alice', 'Task 1', futureTime);
+      storage.createReminder('group1', 'Bob', 'Task 2', futureTime + 1000);
+
+      const reminders = storage.listReminders('group1');
+      expect(reminders).toHaveLength(2);
+      expect(reminders[0].reminderText).toBe('Task 1');
+      expect(reminders[1].reminderText).toBe('Task 2');
+    });
+
+    it('should not list reminders from other groups', () => {
+      createStorage();
+      const futureTime = Date.now() + 60000;
+      storage.createReminder('group1', 'Alice', 'Task 1', futureTime);
+      storage.createReminder('group2', 'Bob', 'Task 2', futureTime);
+
+      const reminders = storage.listReminders('group1');
+      expect(reminders).toHaveLength(1);
+      expect(reminders[0].reminderText).toBe('Task 1');
+    });
+
+    it('should not list sent or cancelled reminders', () => {
+      createStorage();
+      const futureTime = Date.now() + 60000;
+      const id1 = storage.createReminder('group1', 'Alice', 'Sent', futureTime);
+      storage.createReminder('group1', 'Alice', 'Pending', futureTime + 1000);
+      const id3 = storage.createReminder('group1', 'Alice', 'Cancelled', futureTime + 2000);
+
+      vi.spyOn(Date, 'now').mockReturnValue(futureTime + 5000);
+      storage.markReminderSent(id1);
+      vi.restoreAllMocks();
+      storage.cancelReminder(id3, 'group1');
+
+      const reminders = storage.listReminders('group1');
+      expect(reminders).toHaveLength(1);
+      expect(reminders[0].reminderText).toBe('Pending');
+    });
+
+    it('should reject empty groupId', () => {
+      createStorage();
+      expect(() => storage.listReminders('')).toThrow('Invalid groupId: cannot be empty');
+    });
+  });
+
+  describe('close guard for reminder methods', () => {
+    it('should throw on createReminder after close', () => {
+      createStorage();
+      storage.close();
+      expect(() => storage.createReminder('g1', 'Alice', 'Test', Date.now() + 60000)).toThrow('Database is closed');
+    });
+
+    it('should throw on getDueReminders after close', () => {
+      createStorage();
+      storage.close();
+      expect(() => storage.getDueReminders()).toThrow('Database is closed');
+    });
+
+    it('should throw on listReminders after close', () => {
+      createStorage();
+      storage.close();
+      expect(() => storage.listReminders('g1')).toThrow('Database is closed');
+    });
+
+    it('should throw on cancelReminder after close', () => {
+      createStorage();
+      storage.close();
+      expect(() => storage.cancelReminder(1, 'g1')).toThrow('Database is closed');
+    });
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - DB_PATH=/app/data/bot.db
       - SYSTEM_PROMPT=${SYSTEM_PROMPT:-}
       - CLAUDE_MAX_TURNS=${CLAUDE_MAX_TURNS:-1}
+      - BOT_TIMEZONE=${BOT_TIMEZONE:-Australia/Sydney}
     volumes:
       - ./data/bot:/app/data
       - ${HOME}/.claude:/root/.claude:ro


### PR DESCRIPTION
## Summary
- Adds reminder capability to the Signal bot — users can ask Claude to set, list, and cancel reminders in group chat
- Implements a zero-dependency MCP stdio server exposing 3 tools (`set_reminder`, `list_reminders`, `cancel_reminder`) that Claude CLI connects to via `--mcp-config`
- Creates a `ReminderScheduler` that checks for due reminders every ~30 seconds in the existing polling loop and delivers them to the correct Signal group
- Extends SQLite storage with a `reminders` table, WAL mode for concurrent access, and 7 new CRUD methods
- Injects current time/timezone context into system prompt so Claude can parse natural language time expressions

## Architecture
```
User: "claude: remind me at 8:30am next Tuesday about my appointment"
  → Claude parses time → calls set_reminder MCP tool → stored in SQLite
  → Scheduler polls every ~30s → sends reminder to Signal group when due
```

## Files changed
- **New**: `reminderMcpServer.ts`, `reminderScheduler.ts`, 3 test files
- **Modified**: `types.ts`, `storage.ts`, `claudeClient.ts`, `messageHandler.ts`, `config.ts`, `index.ts`, `docker-compose.yml`
- **56 new tests** (167 total), all passing

## Test plan
- [x] `npm test` — 167/167 tests pass across 9 test files
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx biome check` — 0 lint/format errors
- [ ] Manual: send "claude: remind me in 2 minutes to test reminders" in Signal group
- [ ] Manual: verify reminder arrives ~2 minutes later
- [ ] Manual: test list and cancel commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)