### PR TITLE
Move attachments column migration into versioned system

### DIFF
--- a/bot/src/db.ts
+++ b/bot/src/db.ts
@@ -41,7 +41,8 @@ export class DatabaseConnection {
           sender TEXT NOT NULL,
           content TEXT NOT NULL,
           timestamp INTEGER NOT NULL,
-          isBot INTEGER NOT NULL DEFAULT 0
+          isBot INTEGER NOT NULL DEFAULT 0,
+          attachments TEXT
         );
 
         CREATE INDEX IF NOT EXISTS idx_group_timestamp
@@ -106,12 +107,6 @@ export class DatabaseConnection {
           value TEXT NOT NULL
         );
       `);
-
-      // Migration: add attachments column to messages table
-      const cols = this.db.pragma('table_info(messages)') as Array<{ name: string }>;
-      if (!cols.some(c => c.name === 'attachments')) {
-        this.db.exec('ALTER TABLE messages ADD COLUMN attachments TEXT');
-      }
     } catch (error) {
       wrapSqliteError(error, 'create tables');
     }
@@ -129,6 +124,11 @@ export class DatabaseConnection {
       if (currentVersion < 2) {
         this.migrateToV2();
         this.setSchemaVersion(2);
+      }
+
+      if (currentVersion < 3) {
+        this.migrateToV3();
+        this.setSchemaVersion(3);
       }
     } catch (error) {
       wrapSqliteError(error, 'run migrations');
@@ -151,6 +151,14 @@ export class DatabaseConnection {
   }
 
   private migrateToV1(): void {
+    // Add attachments column to messages table (for databases created before it was in CREATE TABLE)
+    const cols = this.db.pragma('table_info(messages)') as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'attachments')) {
+      this.db.exec('ALTER TABLE messages ADD COLUMN attachments TEXT');
+    }
+  }
+
+  private migrateToV2(): void {
     // Add lastAttemptAt and failureReason columns to reminders
     const cols = this.db.pragma('table_info(reminders)') as Array<{ name: string }>;
     const colNames = cols.map(c => c.name);
@@ -166,7 +174,7 @@ export class DatabaseConnection {
     this.db.exec('CREATE INDEX IF NOT EXISTS idx_reminders_group_status ON reminders(groupId, status, dueAt)');
   }
 
-  private migrateToV2(): void {
+  private migrateToV3(): void {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS memories (
         id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/bot/tests/db.test.ts
+++ b/bot/tests/db.test.ts
@@ -125,13 +125,65 @@ describe('DatabaseConnection', () => {
       }
     });
 
+    it('should add attachments column to messages via migration for old databases', () => {
+      const dbPath = createTestDb();
+      // Create a pre-migration database without the attachments column
+      const rawDb = new Database(dbPath);
+      rawDb.pragma('journal_mode = WAL');
+      rawDb.exec(`
+        CREATE TABLE IF NOT EXISTS messages (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          groupId TEXT NOT NULL,
+          sender TEXT NOT NULL,
+          content TEXT NOT NULL,
+          timestamp INTEGER NOT NULL,
+          isBot INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS reminders (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          groupId TEXT NOT NULL,
+          requester TEXT NOT NULL,
+          reminderText TEXT NOT NULL,
+          dueAt INTEGER NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          retryCount INTEGER NOT NULL DEFAULT 0,
+          createdAt INTEGER NOT NULL,
+          sentAt INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS schema_meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+      `);
+      rawDb
+        .prepare('INSERT INTO messages (groupId, sender, content, timestamp, isBot) VALUES (?, ?, ?, ?, ?)')
+        .run('group1', 'Alice', 'Hello', 1000, 0);
+      rawDb.close();
+
+      // Now open with DatabaseConnection which runs migrations
+      const conn = new DatabaseConnection(dbPath);
+      try {
+        const cols = conn.db.pragma('table_info(messages)') as Array<{ name: string }>;
+        const colNames = cols.map(c => c.name);
+        expect(colNames).toContain('attachments');
+
+        // Verify existing data is preserved
+        const row = conn.db.prepare('SELECT * FROM messages WHERE id = 1').get() as any;
+        expect(row.groupId).toBe('group1');
+        expect(row.content).toBe('Hello');
+        expect(row.attachments).toBeNull();
+      } finally {
+        conn.close();
+      }
+    });
+
     it('should track schema version in schema_meta table', () => {
       const conn = new DatabaseConnection(createTestDb());
       try {
         const row = conn.db.prepare("SELECT value FROM schema_meta WHERE key = 'schema_version'").get() as {
           value: string;
         };
-        expect(Number.parseInt(row.value, 10)).toBeGreaterThanOrEqual(1);
+        expect(Number.parseInt(row.value, 10)).toBeGreaterThanOrEqual(2);
       } finally {
         conn.close();
       }
@@ -163,13 +215,13 @@ describe('DatabaseConnection', () => {
       }
     });
 
-    it('should set schema version to 2 after migrations', () => {
+    it('should set schema version to 3 after migrations', () => {
       const conn = new DatabaseConnection(createTestDb());
       try {
         const row = conn.db.prepare("SELECT value FROM schema_meta WHERE key = 'schema_version'").get() as {
           value: string;
         };
-        expect(Number.parseInt(row.value, 10)).toBe(2);
+        expect(Number.parseInt(row.value, 10)).toBe(3);
       } finally {
         conn.close();
       }


### PR DESCRIPTION
## Summary
- Removed ad-hoc `attachments` column migration from `initTables` (pragma check + ALTER TABLE)
- Added `attachments TEXT` directly to the `CREATE TABLE messages` statement for new databases
- Created versioned migration v1 that adds the `attachments` column to existing databases missing it
- Renumbered the existing reminders migration from v1 to v2
- Added test verifying the migration works for databases created without the attachments column

## Test plan
- [x] All 624 existing tests pass
- [x] New test verifies attachments column is added via migration for old databases
- [x] New test verifies existing message data is preserved through migration
- [x] Biome check passes (only pre-existing `index.ts` formatting issue remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)