### PR TITLE
Refactor store layer: tokens util, type fixes, runOp helper

### DIFF
--- a/bot/src/db.ts
+++ b/bot/src/db.ts
@@ -193,6 +193,15 @@ export class DatabaseConnection {
     `);
   }
 
+  runOp<T>(name: string, fn: () => T): T {
+    this.ensureOpen();
+    try {
+      return fn();
+    } catch (error) {
+      wrapSqliteError(error, name);
+    }
+  }
+
   ensureOpen(): void {
     if (this.closed) {
       throw new Error('Database is closed');

--- a/bot/src/mcp/result.ts
+++ b/bot/src/mcp/result.ts
@@ -1,5 +1,7 @@
 import type { ToolResult } from './types';
 
+export { estimateTokens } from '../utils/tokens';
+
 export function ok(text: string): ToolResult {
   return { content: [{ type: 'text', text }] };
 }
@@ -10,10 +12,6 @@ export function error(text: string): ToolResult {
 
 export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : 'Unknown error';
-}
-
-export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 export function catchErrors(

--- a/bot/src/stores/dossierStore.ts
+++ b/bot/src/stores/dossierStore.ts
@@ -1,8 +1,8 @@
 import type Database from 'better-sqlite3';
 import type { DatabaseConnection } from '../db';
 import { wrapSqliteError } from '../db';
-import { estimateTokens } from '../mcp/result';
 import type { Dossier } from '../types';
+import { estimateTokens } from '../utils/tokens';
 
 export const DOSSIER_TOKEN_LIMIT = 1000;
 
@@ -56,25 +56,15 @@ export class DossierStore {
       const row = this.stmts.upsert.get(groupId, personId, displayName, notes, now, now) as Dossier;
       return row;
     } catch (error) {
-      if (
-        error instanceof Error &&
-        (error.message.startsWith('Invalid ') || error.message.startsWith('Notes exceeds'))
-      ) {
-        throw error;
-      }
       wrapSqliteError(error, 'upsert dossier');
     }
   }
 
   get(groupId: string, personId: string): Dossier | null {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('get dossier', () => {
       const row = this.stmts.get.get(groupId, personId) as Dossier | undefined;
       return row ?? null;
-    } catch (error) {
-      wrapSqliteError(error, 'get dossier');
-    }
+    });
   }
 
   getByGroup(groupId: string): Dossier[] {
@@ -91,13 +81,9 @@ export class DossierStore {
   }
 
   delete(groupId: string, personId: string): boolean {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('delete dossier', () => {
       const result = this.stmts.delete.run(groupId, personId);
       return result.changes > 0;
-    } catch (error) {
-      wrapSqliteError(error, 'delete dossier');
-    }
+    });
   }
 }

--- a/bot/src/stores/messageStore.ts
+++ b/bot/src/stores/messageStore.ts
@@ -208,13 +208,9 @@ export class MessageStore {
   }
 
   getDistinctGroupIds(): string[] {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('get distinct group IDs', () => {
       const rows = this.stmts.getDistinctGroupIds.all() as Array<{ groupId: string }>;
       return rows.map(row => row.groupId);
-    } catch (error) {
-      wrapSqliteError(error, 'get distinct group IDs');
-    }
+    });
   }
 }

--- a/bot/src/stores/personaStore.ts
+++ b/bot/src/stores/personaStore.ts
@@ -1,8 +1,14 @@
 import type Database from 'better-sqlite3';
 import type { DatabaseConnection } from '../db';
 import { wrapSqliteError } from '../db';
-import { estimateTokens } from '../mcp/result';
 import type { Persona } from '../types';
+import { estimateTokens } from '../utils/tokens';
+
+type PersonaRow = Omit<Persona, 'isDefault'> & { isDefault: number };
+
+function mapPersonaRow(row: PersonaRow): Persona {
+  return { ...row, isDefault: row.isDefault === 1 };
+}
 
 export const PERSONA_DESCRIPTION_TOKEN_LIMIT = 2000;
 
@@ -24,6 +30,7 @@ export class PersonaStore {
     getActive: Database.Statement;
     clearActive: Database.Statement;
     clearActiveByPersonaId: Database.Statement;
+    seedDefault: Database.Statement;
   };
 
   constructor(conn: DatabaseConnection) {
@@ -70,6 +77,10 @@ export class PersonaStore {
       clearActiveByPersonaId: conn.db.prepare(`
         DELETE FROM active_personas WHERE personaId = ?
       `),
+      seedDefault: conn.db.prepare(`
+        INSERT INTO personas (name, description, tags, isDefault, createdAt, updatedAt)
+        VALUES (?, ?, ?, 1, ?, ?)
+      `),
     };
   }
 
@@ -80,11 +91,13 @@ export class PersonaStore {
       const existing = this.stmts.getByName.get(DEFAULT_PERSONA_NAME);
       if (!existing) {
         const now = Date.now();
-        this.conn.db
-          .prepare(
-            'INSERT INTO personas (name, description, tags, isDefault, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)',
-          )
-          .run(DEFAULT_PERSONA_NAME, DEFAULT_PERSONA_DESCRIPTION, 'default,family,helpful', now, now);
+        this.stmts.seedDefault.run(
+          DEFAULT_PERSONA_NAME,
+          DEFAULT_PERSONA_DESCRIPTION,
+          'default,family,helpful',
+          now,
+          now,
+        );
       }
     } catch (error) {
       wrapSqliteError(error, 'seed default persona');
@@ -111,7 +124,7 @@ export class PersonaStore {
         name,
         description,
         tags,
-        isDefault: 0,
+        isDefault: false,
         createdAt: now,
         updatedAt: now,
       };
@@ -124,32 +137,24 @@ export class PersonaStore {
   }
 
   getById(id: number): Persona | null {
-    this.conn.ensureOpen();
-    try {
-      const row = this.stmts.getById.get(id) as Persona | undefined;
-      return row ?? null;
-    } catch (error) {
-      wrapSqliteError(error, 'get persona');
-    }
+    return this.conn.runOp('get persona', () => {
+      const row = this.stmts.getById.get(id) as PersonaRow | undefined;
+      return row ? mapPersonaRow(row) : null;
+    });
   }
 
   getByName(name: string): Persona | null {
-    this.conn.ensureOpen();
-    try {
-      const row = this.stmts.getByName.get(name) as Persona | undefined;
-      return row ?? null;
-    } catch (error) {
-      wrapSqliteError(error, 'get persona by name');
-    }
+    return this.conn.runOp('get persona by name', () => {
+      const row = this.stmts.getByName.get(name) as PersonaRow | undefined;
+      return row ? mapPersonaRow(row) : null;
+    });
   }
 
   list(): Persona[] {
-    this.conn.ensureOpen();
-    try {
-      return this.stmts.list.all() as Persona[];
-    } catch (error) {
-      wrapSqliteError(error, 'list personas');
-    }
+    return this.conn.runOp('list personas', () => {
+      const rows = this.stmts.list.all() as PersonaRow[];
+      return rows.map(mapPersonaRow);
+    });
   }
 
   update(id: number, name: string, description: string, tags: string): boolean {
@@ -174,26 +179,23 @@ export class PersonaStore {
   }
 
   delete(id: number): boolean {
-    this.conn.ensureOpen();
-
     try {
-      // Clean up any active_personas references first
-      this.stmts.clearActiveByPersonaId.run(id);
-      const result = this.stmts.delete.run(id);
-      return result.changes > 0;
+      return this.conn.transaction(() => {
+        // Clean up any active_personas references first
+        this.stmts.clearActiveByPersonaId.run(id);
+        const result = this.stmts.delete.run(id);
+        return result.changes > 0;
+      });
     } catch (error) {
       wrapSqliteError(error, 'delete persona');
     }
   }
 
   getDefault(): Persona | null {
-    this.conn.ensureOpen();
-    try {
-      const row = this.stmts.getDefault.get() as Persona | undefined;
-      return row ?? null;
-    } catch (error) {
-      wrapSqliteError(error, 'get default persona');
-    }
+    return this.conn.runOp('get default persona', () => {
+      const row = this.stmts.getDefault.get() as PersonaRow | undefined;
+      return row ? mapPersonaRow(row) : null;
+    });
   }
 
   setActive(groupId: string, personaId: number): void {
@@ -212,8 +214,8 @@ export class PersonaStore {
   getActiveForGroup(groupId: string): Persona | null {
     this.conn.ensureOpen();
     try {
-      const row = this.stmts.getActive.get(groupId) as Persona | undefined;
-      if (row) return row;
+      const row = this.stmts.getActive.get(groupId) as PersonaRow | undefined;
+      if (row) return mapPersonaRow(row);
       // Fall back to default persona
       return this.getDefault();
     } catch (error) {
@@ -222,11 +224,8 @@ export class PersonaStore {
   }
 
   clearActive(groupId: string): void {
-    this.conn.ensureOpen();
-    try {
+    this.conn.runOp('clear active persona', () => {
       this.stmts.clearActive.run(groupId);
-    } catch (error) {
-      wrapSqliteError(error, 'clear active persona');
-    }
+    });
   }
 }

--- a/bot/src/stores/reminderStore.ts
+++ b/bot/src/stores/reminderStore.ts
@@ -97,68 +97,44 @@ export class ReminderStore {
   }
 
   getDueByGroup(groupId: string, now: number, limit: number): Reminder[] {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('get due reminders by group', () => {
       const rows = this.stmts.getDueByGroup.all(groupId, now, limit) as Array<ReminderRow>;
       return rows.map(mapReminderRow);
-    } catch (error) {
-      wrapSqliteError(error, 'get due reminders by group');
-    }
+    });
   }
 
   getGroupsWithDueReminders(now: number): string[] {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('get groups with due reminders', () => {
       const rows = this.stmts.getGroupsWithDueReminders.all(now) as Array<{ groupId: string }>;
       return rows.map(r => r.groupId);
-    } catch (error) {
-      wrapSqliteError(error, 'get groups with due reminders');
-    }
+    });
   }
 
   markSent(id: number): boolean {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('mark reminder sent', () => {
       const result = this.stmts.markSent.run(Date.now(), id);
       return result.changes > 0;
-    } catch (error) {
-      wrapSqliteError(error, 'mark reminder sent');
-    }
+    });
   }
 
   markFailed(id: number, reason: string): boolean {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('mark reminder failed', () => {
       const result = this.stmts.markFailed.run(reason, id);
       return result.changes > 0;
-    } catch (error) {
-      wrapSqliteError(error, 'mark reminder failed');
-    }
+    });
   }
 
   recordAttempt(id: number): void {
-    this.conn.ensureOpen();
-
-    try {
+    this.conn.runOp('record attempt', () => {
       this.stmts.recordAttempt.run(Date.now(), id);
-    } catch (error) {
-      wrapSqliteError(error, 'record attempt');
-    }
+    });
   }
 
   cancel(id: number, groupId: string): boolean {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('cancel reminder', () => {
       const result = this.stmts.cancel.run(id, groupId);
       return result.changes > 0;
-    } catch (error) {
-      wrapSqliteError(error, 'cancel reminder');
-    }
+    });
   }
 
   listPending(groupId: string): Reminder[] {
@@ -177,14 +153,10 @@ export class ReminderStore {
 
   // Legacy compatibility methods (used by existing Storage facade)
   getDueReminders(now?: number, limit = 50): Reminder[] {
-    this.conn.ensureOpen();
-
-    try {
+    return this.conn.runOp('get due reminders', () => {
       const rows = this.stmts.selectDueReminders.all(now ?? Date.now(), limit) as Array<ReminderRow>;
       return rows.map(mapReminderRow);
-    } catch (error) {
-      wrapSqliteError(error, 'get due reminders');
-    }
+    });
   }
 
   /**
@@ -198,12 +170,8 @@ export class ReminderStore {
    * Legacy: increment retry without setting lastAttemptAt
    */
   incrementRetry(id: number): void {
-    this.conn.ensureOpen();
-
-    try {
+    this.conn.runOp('increment reminder retry', () => {
       this.stmts.incrementRetry.run(id);
-    } catch (error) {
-      wrapSqliteError(error, 'increment reminder retry');
-    }
+    });
   }
 }

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -60,7 +60,7 @@ export interface Persona {
   name: string;
   description: string;
   tags: string;
-  isDefault: number;
+  isDefault: boolean;
   createdAt: number;
   updatedAt: number;
 }

--- a/bot/src/utils/tokens.ts
+++ b/bot/src/utils/tokens.ts
@@ -1,0 +1,3 @@
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/bot/tests/messageHandler.test.ts
+++ b/bot/tests/messageHandler.test.ts
@@ -976,7 +976,7 @@ describe('MessageHandler', () => {
           name: 'Pirate',
           description: 'Ye be a pirate captain! Speak in pirate dialect.',
           tags: 'fun,pirate',
-          isDefault: 0,
+          isDefault: false,
           createdAt: 1000,
           updatedAt: 1000,
         });

--- a/bot/tests/storage.personas.test.ts
+++ b/bot/tests/storage.personas.test.ts
@@ -28,7 +28,7 @@ describe('Storage - Personas', () => {
       const defaultPersona = storage.getDefaultPersona();
       expect(defaultPersona).not.toBeNull();
       expect(defaultPersona?.name).toBe('Default Assistant');
-      expect(defaultPersona?.isDefault).toBe(1);
+      expect(defaultPersona?.isDefault).toBe(true);
       expect(defaultPersona?.description).toContain('helpful family assistant');
     });
 
@@ -50,7 +50,7 @@ describe('Storage - Personas', () => {
         name: 'Pirate',
         description: 'Ye be a pirate captain!',
         tags: 'fun,pirate',
-        isDefault: 0,
+        isDefault: false,
       });
       expect(persona.id).toBeGreaterThan(0);
       expect(persona.createdAt).toBeGreaterThan(0);
@@ -138,7 +138,7 @@ describe('Storage - Personas', () => {
     it('should include the seeded default persona', () => {
       createStorage();
       const personas = storage.listPersonas();
-      expect(personas.some(p => p.isDefault === 1)).toBe(true);
+      expect(personas.some(p => p.isDefault === true)).toBe(true);
     });
   });
 
@@ -211,7 +211,7 @@ describe('Storage - Personas', () => {
       storage.deletePersona(created.id);
       // Group should fall back to default
       const active = storage.getActivePersonaForGroup('group1');
-      expect(active?.isDefault).toBe(1);
+      expect(active?.isDefault).toBe(true);
     });
   });
 
@@ -220,7 +220,7 @@ describe('Storage - Personas', () => {
       createStorage();
       const persona = storage.getDefaultPersona();
       expect(persona).not.toBeNull();
-      expect(persona?.isDefault).toBe(1);
+      expect(persona?.isDefault).toBe(true);
       expect(persona?.name).toBe('Default Assistant');
     });
   });
@@ -265,7 +265,7 @@ describe('Storage - Personas', () => {
       createStorage();
       const active = storage.getActivePersonaForGroup('group1');
       expect(active).not.toBeNull();
-      expect(active?.isDefault).toBe(1);
+      expect(active?.isDefault).toBe(true);
     });
 
     it('should support different personas per group', () => {
@@ -286,7 +286,7 @@ describe('Storage - Personas', () => {
       storage.setActivePersona('group1', created.id);
       storage.clearActivePersona('group1');
       const active = storage.getActivePersonaForGroup('group1');
-      expect(active?.isDefault).toBe(1);
+      expect(active?.isDefault).toBe(true);
     });
 
     it('should be a no-op if no active persona set', () => {

--- a/bot/tests/stores/personaStore.test.ts
+++ b/bot/tests/stores/personaStore.test.ts
@@ -31,7 +31,7 @@ describe('PersonaStore', () => {
       const defaultPersona = store.getDefault();
       expect(defaultPersona).not.toBeNull();
       expect(defaultPersona?.name).toBe('Default Assistant');
-      expect(defaultPersona?.isDefault).toBe(1);
+      expect(defaultPersona?.isDefault).toBe(true);
       expect(defaultPersona?.description).toContain('helpful family assistant');
     });
 
@@ -53,7 +53,7 @@ describe('PersonaStore', () => {
         name: 'Pirate',
         description: 'Ye be a pirate captain!',
         tags: 'fun,pirate',
-        isDefault: 0,
+        isDefault: false,
       });
       expect(persona.id).toBeGreaterThan(0);
       expect(persona.createdAt).toBeGreaterThan(0);
@@ -142,7 +142,7 @@ describe('PersonaStore', () => {
       setup();
       store.seedDefault();
       const personas = store.list();
-      expect(personas.some(p => p.isDefault === 1)).toBe(true);
+      expect(personas.some(p => p.isDefault === true)).toBe(true);
     });
   });
 
@@ -215,7 +215,7 @@ describe('PersonaStore', () => {
       store.setActive('group1', created.id);
       store.delete(created.id);
       const active = store.getActiveForGroup('group1');
-      expect(active?.isDefault).toBe(1);
+      expect(active?.isDefault).toBe(true);
     });
   });
 
@@ -225,7 +225,7 @@ describe('PersonaStore', () => {
       store.seedDefault();
       const persona = store.getDefault();
       expect(persona).not.toBeNull();
-      expect(persona?.isDefault).toBe(1);
+      expect(persona?.isDefault).toBe(true);
       expect(persona?.name).toBe('Default Assistant');
     });
   });
@@ -274,7 +274,7 @@ describe('PersonaStore', () => {
       store.seedDefault();
       const active = store.getActiveForGroup('group1');
       expect(active).not.toBeNull();
-      expect(active?.isDefault).toBe(1);
+      expect(active?.isDefault).toBe(true);
     });
 
     it('should support different personas per group', () => {
@@ -297,7 +297,7 @@ describe('PersonaStore', () => {
       store.setActive('group1', created.id);
       store.clearActive('group1');
       const active = store.getActiveForGroup('group1');
-      expect(active?.isDefault).toBe(1);
+      expect(active?.isDefault).toBe(true);
     });
 
     it('should be a no-op if no active persona set', () => {


### PR DESCRIPTION
## Summary
- Extract `estimateTokens` into `bot/src/utils/tokens.ts` with re-export from `mcp/result.ts` for backward compatibility
- Remove dead error-rethrow guards in `DossierStore.upsert` catch block (validation throws before try block, so catch never sees those errors)
- Wrap `PersonaStore.delete` in a transaction for atomicity (two SQL operations: clear active refs + delete)
- Change `Persona.isDefault` from `number` to `boolean` with proper SQLite integer-to-boolean row mapping
- Move `PersonaStore.seedDefault` inline `db.prepare()` into the `stmts` object to match codebase conventions
- Add `DatabaseConnection.runOp<T>(name, fn)` helper to reduce repeated `ensureOpen(); try { ... } catch { wrapSqliteError() }` boilerplate; migrate simple store methods to use it

## Test plan
- [x] All 623 tests pass
- [x] Biome check passes (pre-existing `index.ts` format issue excluded)
- [x] `isDefault` assertions updated from `1`/`0` to `true`/`false` across all test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)