### PR TITLE
Batch message handling to prevent duplicate responses

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -86,9 +86,10 @@ async function main() {
         messagesSinceHeartbeat = 0;
       }
 
+      // Extract and group messages by groupId
+      const byGroup = new Map<string, import('./types').ExtractedMessage[]>();
       for (const signalMsg of messages) {
         const data = signalClient.extractMessageData(signalMsg);
-
         if (!data) {
           logger.compact('SKIP', `(no data): ${JSON.stringify(signalMsg).substring(0, 200)}`);
           continue;
@@ -100,9 +101,17 @@ async function main() {
         } else {
           logger.compact('RECV', `[${data.groupId}] ${data.sender}: ${data.content.substring(0, 80)}`);
         }
-        await messageHandler.handleMessage(data.groupId, data.sender, data.content, data.timestamp, data.attachments, {
-          storeOnly,
-        });
+
+        if (!byGroup.has(data.groupId)) {
+          byGroup.set(data.groupId, []);
+        }
+        byGroup.get(data.groupId)?.push(data);
+      }
+
+      // Process each group's messages as a batch
+      for (const [groupId, batch] of byGroup) {
+        const storeOnly = config.testChannelOnly && groupId !== config.testGroupId;
+        await messageHandler.handleMessageBatch(groupId, batch, { storeOnly });
       }
 
       // Check for due reminders periodically

--- a/bot/src/messageHandler.ts
+++ b/bot/src/messageHandler.ts
@@ -5,8 +5,10 @@ import { MentionDetector } from './mentionDetector';
 import { MessageDeduplicator } from './messageDeduplicator';
 import type { SignalClient } from './signalClient';
 import type { Storage } from './storage';
-import type { AppConfig, LLMClient, Message, SignalAttachment } from './types';
+import type { AppConfig, ExtractedMessage, LLMClient, Message, SignalAttachment } from './types';
 import { TypingIndicatorManager } from './typingIndicator';
+
+export const REALTIME_THRESHOLD_MS = 5000;
 
 export interface MessageHandlerOptions {
   systemPrompt?: string;
@@ -121,6 +123,107 @@ export class MessageHandler {
     );
   }
 
+  async handleMessageBatch(
+    groupId: string,
+    messages: ExtractedMessage[],
+    options?: { storeOnly?: boolean },
+  ): Promise<void> {
+    const validMessages: ExtractedMessage[] = [];
+    for (const msg of messages) {
+      if (this.appConfig.botPhoneNumber && msg.sender === this.appConfig.botPhoneNumber) {
+        continue;
+      }
+      if (this.deduplicator.isDuplicate(groupId, msg.sender, msg.timestamp)) {
+        continue;
+      }
+      validMessages.push(msg);
+    }
+
+    const mentionMessages = validMessages.filter(msg => this.mentionDetector.isMentioned(msg.content));
+
+    let history: Message[] = [];
+    let historyFormatted: string[] | undefined;
+    if (mentionMessages.length > 0 && !options?.storeOnly) {
+      const batch = this.storage.getRecentMessages(groupId, this.contextWindowSize);
+      const fitted = this.contextBuilder.fitToTokenBudget(batch);
+      history = fitted.messages;
+      historyFormatted = fitted.formatted;
+    }
+
+    for (const msg of validMessages) {
+      this.storage.addMessage({
+        groupId,
+        sender: msg.sender,
+        content: msg.content,
+        timestamp: msg.timestamp,
+        isBot: false,
+        attachments: msg.attachments.length > 0 ? msg.attachments : undefined,
+      });
+    }
+
+    if (options?.storeOnly || mentionMessages.length === 0) {
+      return;
+    }
+
+    // Classify mentions as missed vs real-time
+    const now = Date.now();
+    const missed = mentionMessages.filter(m => now - m.timestamp > REALTIME_THRESHOLD_MS);
+    const realtime = mentionMessages.filter(m => now - m.timestamp <= REALTIME_THRESHOLD_MS);
+
+    // Missed mentions: batch into a single LLM call if multiple, or process individually
+    if (missed.length > 1) {
+      const latest = missed[missed.length - 1];
+      await this.typingManager.withTyping(groupId, () =>
+        this.processLlmRequest(
+          groupId,
+          latest.sender,
+          latest.content,
+          latest.attachments,
+          history,
+          historyFormatted,
+          this.buildMissedMessageFraming(missed, now),
+        ),
+      );
+    } else if (missed.length === 1) {
+      const msg = missed[0];
+      await this.typingManager.withTyping(groupId, () =>
+        this.processLlmRequest(groupId, msg.sender, msg.content, msg.attachments, history, historyFormatted),
+      );
+    }
+
+    // Real-time mentions: process individually with fresh history each time
+    for (const msg of realtime) {
+      const freshBatch = this.storage.getRecentMessages(groupId, this.contextWindowSize);
+      const freshFitted = this.contextBuilder.fitToTokenBudget(freshBatch);
+      await this.typingManager.withTyping(groupId, () =>
+        this.processLlmRequest(
+          groupId,
+          msg.sender,
+          msg.content,
+          msg.attachments,
+          freshFitted.messages,
+          freshFitted.formatted,
+        ),
+      );
+    }
+  }
+
+  private buildMissedMessageFraming(missed: ExtractedMessage[], now: number): string {
+    const lines = missed.map(m => {
+      const agoSeconds = Math.round((now - m.timestamp) / 1000);
+      let agoStr: string;
+      if (agoSeconds < 60) {
+        agoStr = `${agoSeconds}s ago`;
+      } else if (agoSeconds < 3600) {
+        agoStr = `${Math.round(agoSeconds / 60)} min ago`;
+      } else {
+        agoStr = `${Math.round(agoSeconds / 3600)}h ago`;
+      }
+      return `- [${m.sender}] (${agoStr}): "${m.content}"`;
+    });
+    return `You were offline and missed the following messages:\n${lines.join('\n')}\n\nRespond to all of these in a single message.`;
+  }
+
   /** Assemble additional context (dossiers, memories, skills, persona) for the LLM request. */
   private assembleAdditionalContext(groupId: string): {
     additionalContext: string | undefined;
@@ -177,6 +280,7 @@ export class MessageHandler {
     attachments: SignalAttachment[],
     history: Message[],
     historyFormatted?: string[],
+    missedFraming?: string,
   ): Promise<void> {
     try {
       // Extract query
@@ -198,6 +302,10 @@ export class MessageHandler {
       if (allAttachmentLines.length > 0) {
         const attachmentBlock = allAttachmentLines.join('\n');
         queryWithAttachments = query ? `${query}\n\n${attachmentBlock}` : attachmentBlock;
+      }
+
+      if (missedFraming) {
+        queryWithAttachments = missedFraming + (queryWithAttachments ? `\n\n${queryWithAttachments}` : '');
       }
 
       // Build additional system context (dossiers + memories + skills + persona)

--- a/bot/src/signalClient.ts
+++ b/bot/src/signalClient.ts
@@ -1,5 +1,5 @@
 import { logger } from './logger';
-import type { SignalAttachment, SignalMessage } from './types';
+import type { ExtractedMessage, SignalMessage } from './types';
 
 export class SignalClient {
   private baseUrl: string;
@@ -85,13 +85,7 @@ export class SignalClient {
     throw new Error(`signal-cli not reachable at ${this.baseUrl} after ${maxRetries} attempts`);
   }
 
-  extractMessageData(signalMsg: SignalMessage): {
-    sender: string;
-    content: string;
-    groupId: string;
-    timestamp: number;
-    attachments: SignalAttachment[];
-  } | null {
+  extractMessageData(signalMsg: SignalMessage): ExtractedMessage | null {
     const envelope = signalMsg.envelope;
     const dataMessage = envelope.dataMessage;
     const attachments = dataMessage?.attachments ?? [];

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -120,3 +120,11 @@ export interface SignalMessage {
     };
   };
 }
+
+export interface ExtractedMessage {
+  sender: string;
+  content: string;
+  groupId: string;
+  timestamp: number;
+  attachments: SignalAttachment[];
+}

--- a/bot/tests/messageHandler.batch.test.ts
+++ b/bot/tests/messageHandler.batch.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageHandler } from '../src/messageHandler';
+import type { SignalClient } from '../src/signalClient';
+import type { Storage } from '../src/storage';
+import type { AppConfig, ExtractedMessage, LLMClient } from '../src/types';
+
+vi.mock('../src/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    group: vi.fn(),
+    step: vi.fn(),
+    groupEnd: vi.fn(),
+    compact: vi.fn(),
+  },
+}));
+
+function makeAppConfig(overrides?: Partial<AppConfig>): AppConfig {
+  return {
+    dbPath: './data/bot.db',
+    timezone: 'Australia/Sydney',
+    githubRepo: '',
+    sourceRoot: '',
+    signalCliUrl: '',
+    botPhoneNumber: '+1234567890',
+    attachmentsDir: './data/signal-attachments',
+    whisperModelPath: './models/ggml-base.en.bin',
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<ExtractedMessage> & { content: string }): ExtractedMessage {
+  return {
+    sender: '+61400111222',
+    groupId: 'g1',
+    timestamp: Date.now() - 60000,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+describe('MessageHandler.handleMessageBatch', () => {
+  let mockStorage: Storage;
+  let mockLLM: LLMClient;
+  let mockSignal: SignalClient;
+  let handler: MessageHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockStorage = {
+      addMessage: vi.fn(),
+      getRecentMessages: vi.fn().mockReturnValue([]),
+      trimMessages: vi.fn(),
+      getDossiersByGroup: vi.fn().mockReturnValue([]),
+      getMemoriesByGroup: vi.fn().mockReturnValue([]),
+      getActivePersonaForGroup: vi.fn().mockReturnValue(null),
+    } as any;
+
+    mockLLM = {
+      generateResponse: vi.fn().mockResolvedValue({
+        content: 'Test response',
+        tokensUsed: 25,
+        sentViaMcp: false,
+        mcpMessages: [],
+      }),
+    };
+
+    mockSignal = {
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      sendTyping: vi.fn().mockResolvedValue(undefined),
+      stopTyping: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    handler = new MessageHandler(['claude:'], {
+      storage: mockStorage,
+      llmClient: mockLLM,
+      signalClient: mockSignal,
+      appConfig: makeAppConfig(),
+    });
+  });
+
+  it('should store all messages in the batch', async () => {
+    const messages = [
+      makeMessage({ content: 'hello', timestamp: 1000 }),
+      makeMessage({ content: 'claude: hey', timestamp: 2000 }),
+    ];
+
+    await handler.handleMessageBatch('g1', messages);
+
+    // 2 user messages + 1 bot response from LLM dispatch
+    expect(mockStorage.addMessage).toHaveBeenCalledTimes(3);
+    expect(mockStorage.addMessage).toHaveBeenCalledWith(expect.objectContaining({ content: 'hello', timestamp: 1000 }));
+    expect(mockStorage.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'claude: hey', timestamp: 2000 }),
+    );
+  });
+
+  it('should not call LLM when no messages contain mentions', async () => {
+    const messages = [makeMessage({ content: 'hello' }), makeMessage({ content: 'how are you' })];
+
+    await handler.handleMessageBatch('g1', messages);
+
+    expect(mockLLM.generateResponse).not.toHaveBeenCalled();
+  });
+
+  it('should store messages but not call LLM when storeOnly is true', async () => {
+    const messages = [makeMessage({ content: 'claude: hello' })];
+
+    await handler.handleMessageBatch('g1', messages, { storeOnly: true });
+
+    expect(mockStorage.addMessage).toHaveBeenCalledTimes(1);
+    expect(mockLLM.generateResponse).not.toHaveBeenCalled();
+  });
+
+  it('should skip messages from the bot itself', async () => {
+    const messages = [
+      makeMessage({ content: 'claude: hello', sender: '+1234567890' }),
+      makeMessage({ content: 'claude: hey', sender: '+61400111222' }),
+    ];
+
+    await handler.handleMessageBatch('g1', messages);
+
+    // 1 user message + 1 bot response from LLM dispatch
+    expect(mockStorage.addMessage).toHaveBeenCalledTimes(2);
+    expect(mockStorage.addMessage).toHaveBeenCalledWith(expect.objectContaining({ sender: '+61400111222' }));
+  });
+
+  it('should skip duplicate messages', async () => {
+    const messages = [
+      makeMessage({ content: 'claude: hello', sender: '+61400111222', timestamp: 1000 }),
+      makeMessage({ content: 'claude: hello', sender: '+61400111222', timestamp: 1000 }),
+    ];
+
+    await handler.handleMessageBatch('g1', messages);
+
+    // 1 user message (dedup removes second) + 1 bot response from LLM dispatch
+    expect(mockStorage.addMessage).toHaveBeenCalledTimes(2);
+  });
+
+  describe('missed message batching', () => {
+    it('should make only one LLM call for multiple missed mentions', async () => {
+      const now = Date.now();
+      const messages = [
+        makeMessage({ content: 'claude: you awake?', timestamp: now - 60000 }),
+        makeMessage({ content: 'claude: hello?', timestamp: now - 30000 }),
+        makeMessage({ content: 'claude: anyone there?', timestamp: now - 10000 }),
+      ];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      expect(mockLLM.generateResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use the latest missed mention as the primary query', async () => {
+      const now = Date.now();
+      const messages = [
+        makeMessage({ content: 'claude: first question', timestamp: now - 60000 }),
+        makeMessage({ content: 'claude: second question', timestamp: now - 10000 }),
+      ];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      const callArgs = (mockLLM.generateResponse as ReturnType<typeof vi.fn>).mock.calls[0];
+      const llmMessages = callArgs[0];
+      const lastUserMsg = llmMessages[llmMessages.length - 1];
+      expect(lastUserMsg.content).toContain('second question');
+    });
+
+    it('should include "you were offline" framing for multiple missed mentions', async () => {
+      const now = Date.now();
+      const messages = [
+        makeMessage({ content: 'claude: question one', sender: '+61400111222', timestamp: now - 120000 }),
+        makeMessage({ content: 'claude: question two', sender: '+61400333444', timestamp: now - 60000 }),
+      ];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      const callArgs = (mockLLM.generateResponse as ReturnType<typeof vi.fn>).mock.calls[0];
+      const llmMessages = callArgs[0];
+      const lastUserMsg = llmMessages[llmMessages.length - 1];
+      expect(lastUserMsg.content).toContain('You were offline and missed the following messages:');
+      expect(lastUserMsg.content).toContain('+61400111222');
+      expect(lastUserMsg.content).toContain('+61400333444');
+      expect(lastUserMsg.content).toContain('question one');
+      expect(lastUserMsg.content).toContain('Respond to all of these in a single message');
+    });
+
+    it('should NOT include offline framing for a single missed mention', async () => {
+      const now = Date.now();
+      const messages = [makeMessage({ content: 'claude: hello', timestamp: now - 60000 })];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      const callArgs = (mockLLM.generateResponse as ReturnType<typeof vi.fn>).mock.calls[0];
+      const llmMessages = callArgs[0];
+      const lastUserMsg = llmMessages[llmMessages.length - 1];
+      expect(lastUserMsg.content).not.toContain('You were offline');
+      expect(lastUserMsg.content).toContain('hello');
+    });
+  });
+
+  describe('real-time mention handling', () => {
+    it('should process each real-time mention individually', async () => {
+      const now = Date.now();
+      const messages = [
+        makeMessage({ content: 'claude: hi', sender: '+61400111222', timestamp: now }),
+        makeMessage({ content: 'claude: hey', sender: '+61400333444', timestamp: now + 100 }),
+      ];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      expect(mockLLM.generateResponse).toHaveBeenCalledTimes(2);
+    });
+
+    it('should NOT include offline framing for real-time mentions', async () => {
+      const now = Date.now();
+      const messages = [makeMessage({ content: 'claude: hello', timestamp: now })];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      const callArgs = (mockLLM.generateResponse as ReturnType<typeof vi.fn>).mock.calls[0];
+      const llmMessages = callArgs[0];
+      const lastUserMsg = llmMessages[llmMessages.length - 1];
+      expect(lastUserMsg.content).not.toContain('You were offline');
+    });
+  });
+
+  describe('mixed missed and real-time mentions', () => {
+    it('should batch missed mentions and process real-time ones individually', async () => {
+      const now = Date.now();
+      const messages = [
+        makeMessage({ content: 'claude: old question 1', timestamp: now - 60000 }),
+        makeMessage({ content: 'claude: old question 2', timestamp: now - 30000 }),
+        makeMessage({ content: 'claude: new question', timestamp: now }),
+      ];
+
+      await handler.handleMessageBatch('g1', messages);
+
+      // 1 batched call for the 2 missed + 1 individual call for the real-time
+      expect(mockLLM.generateResponse).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('handleMessage backward compatibility', () => {
+    it('should still work as before for single messages', async () => {
+      await handler.handleMessage('g1', '+61400111222', 'claude: hello', Date.now());
+
+      expect(mockLLM.generateResponse).toHaveBeenCalledTimes(1);
+      expect(mockStorage.addMessage).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- When the bot comes back online after being offline, missed mentions are now batched into a single LLM call per group instead of responding to each one individually
- Mentions are classified as "missed" (>5s old) vs "real-time" based on timestamp age — missed get batched with "you were offline" framing, real-time are processed individually as before
- Polling loop in index.ts now groups messages by groupId and calls `handleMessageBatch` per group

## Test plan
- [x] 13 new tests in `messageHandler.batch.test.ts` covering store/filter, missed batching, real-time, mixed, and backward compat
- [x] Full suite passes (678 tests, 0 failures)
- [x] Lint clean (`npm run check`)
- [ ] Manual test: stop bot, send multiple mentions, restart bot, verify single response

🤖 Generated with [Claude Code](https://claude.com/claude-code)