### PR TITLE
Clean up MCP servers: entrypoints, validation, and consistency

### DIFF
--- a/bot/src/mcp/registry.ts
+++ b/bot/src/mcp/registry.ts
@@ -88,7 +88,7 @@ export function buildMcpConfig(context: MessageContext): { mcpServers: Record<st
   const mcpServers: Record<string, unknown> = {};
 
   for (const server of ALL_SERVERS) {
-    const resolved = resolveMcpServerPath(`servers/${server.entrypoint.replace('mcp/servers/', '')}`);
+    const resolved = resolveMcpServerPath(`servers/${server.entrypoint}`);
     const env: Record<string, string> = {};
     for (const [envKey, contextField] of Object.entries(server.envMapping)) {
       const value = context[contextField];

--- a/bot/src/mcp/servers/dossiers.ts
+++ b/bot/src/mcp/servers/dossiers.ts
@@ -4,7 +4,7 @@ import { readStorageEnv } from '../env';
 import { catchErrors, estimateTokens, ok } from '../result';
 import { runServer } from '../runServer';
 import type { McpServerDefinition } from '../types';
-import { requireGroupId, requireString } from '../validate';
+import { optionalString, requireGroupId, requireString } from '../validate';
 
 const TOOLS = [
   {
@@ -52,16 +52,16 @@ let groupId: string;
 export const dossierServer: McpServerDefinition = {
   serverName: 'signal-bot-dossiers',
   configKey: 'dossiers',
-  entrypoint: 'mcp/servers/dossiers',
+  entrypoint: 'dossiers',
   tools: TOOLS,
-  envMapping: { DB_PATH: 'dbPath', MCP_GROUP_ID: 'groupId', MCP_SENDER: 'sender' },
+  envMapping: { DB_PATH: 'dbPath', MCP_GROUP_ID: 'groupId' },
   handlers: {
     update_dossier(args) {
       const personId = requireString(args, 'personId');
       if (personId.error) return personId.error;
       const displayName = requireString(args, 'displayName');
       if (displayName.error) return displayName.error;
-      const notes = (args.notes as string) ?? '';
+      const notes = optionalString(args, 'notes', '');
       const groupErr = requireGroupId(groupId);
       if (groupErr) return groupErr;
 
@@ -108,7 +108,7 @@ export const dossierServer: McpServerDefinition = {
     conn = new DatabaseConnection(env.dbPath);
     store = new DossierStore(conn);
     groupId = env.groupId;
-    console.error(`Dossier MCP server started (group: ${groupId || 'none'}, sender: ${env.sender || 'none'})`);
+    console.error(`Dossier MCP server started (group: ${groupId || 'none'})`);
   },
   onClose() {
     conn.close();

--- a/bot/src/mcp/servers/github.ts
+++ b/bot/src/mcp/servers/github.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { readStorageEnv } from '../env';
 import { catchErrors, error, ok } from '../result';
 import { runServer } from '../runServer';
 import type { McpServerDefinition } from '../types';
@@ -42,7 +43,7 @@ let sender: string;
 export const githubServer: McpServerDefinition = {
   serverName: 'signal-bot-github',
   configKey: 'github',
-  entrypoint: 'mcp/servers/github',
+  entrypoint: 'github',
   tools: TOOLS,
   envMapping: { GITHUB_REPO: 'githubRepo', MCP_SENDER: 'sender' },
   handlers: {
@@ -51,7 +52,7 @@ export const githubServer: McpServerDefinition = {
       if (title.error) return title.error;
       const body = requireString(args, 'body');
       if (body.error) return body.error;
-      const labels = (args.labels as string[]) || ['feature-request'];
+      const labels = Array.isArray(args.labels) ? (args.labels as string[]) : ['feature-request'];
 
       if (!githubRepo) {
         return error('GITHUB_REPO environment variable is not configured.');
@@ -76,8 +77,9 @@ export const githubServer: McpServerDefinition = {
     },
   },
   onInit() {
+    const env = readStorageEnv();
     githubRepo = process.env.GITHUB_REPO || '';
-    sender = process.env.MCP_SENDER || '';
+    sender = env.sender;
     console.error('GitHub MCP server started');
   },
 };

--- a/bot/src/mcp/servers/messageHistory.ts
+++ b/bot/src/mcp/servers/messageHistory.ts
@@ -78,7 +78,7 @@ function formatMessages(messages: Message[]): string {
 export const messageHistoryServer: McpServerDefinition = {
   serverName: 'signal-bot-message-history',
   configKey: 'history',
-  entrypoint: 'mcp/servers/messageHistory',
+  entrypoint: 'messageHistory',
   tools: TOOLS,
   envMapping: { DB_PATH: 'dbPath', MCP_GROUP_ID: 'groupId', TZ: 'timezone' },
   handlers: {

--- a/bot/src/mcp/servers/personas.ts
+++ b/bot/src/mcp/servers/personas.ts
@@ -4,7 +4,7 @@ import { readStorageEnv } from '../env';
 import { catchErrors, error, ok } from '../result';
 import { runServer } from '../runServer';
 import type { McpServerDefinition } from '../types';
-import { requireGroupId, requireNumber, requireString } from '../validate';
+import { optionalString, requireGroupId, requireNumber, requireString } from '../validate';
 
 const TOOLS = [
   {
@@ -107,7 +107,7 @@ function resolvePersona(identifier: string) {
 export const personaServer: McpServerDefinition = {
   serverName: 'signal-bot-personas',
   configKey: 'personas',
-  entrypoint: 'mcp/servers/personas',
+  entrypoint: 'personas',
   tools: TOOLS,
   envMapping: { DB_PATH: 'dbPath', MCP_GROUP_ID: 'groupId', MCP_SENDER: 'sender' },
   handlers: {
@@ -116,7 +116,7 @@ export const personaServer: McpServerDefinition = {
       if (name.error) return name.error;
       const description = requireString(args, 'description');
       if (description.error) return description.error;
-      const tags = (args.tags as string) ?? '';
+      const tags = optionalString(args, 'tags', '');
 
       return catchErrors(() => {
         const persona = store.create(name.value, description.value, tags);
@@ -143,12 +143,15 @@ export const personaServer: McpServerDefinition = {
     },
 
     list_personas() {
+      const groupErr = requireGroupId(groupId);
+      if (groupErr) return groupErr;
+
       const personas = store.list();
       if (personas.length === 0) {
         return ok('No personas found.');
       }
 
-      const active = groupId ? store.getActiveForGroup(groupId) : null;
+      const active = store.getActiveForGroup(groupId);
 
       const lines = personas.map(p => {
         const isActive = active && active.id === p.id;
@@ -168,7 +171,7 @@ export const personaServer: McpServerDefinition = {
       if (name.error) return name.error;
       const description = requireString(args, 'description');
       if (description.error) return description.error;
-      const tags = (args.tags as string) ?? '';
+      const tags = optionalString(args, 'tags', '');
 
       return catchErrors(() => {
         const result = store.update(id.value, name.value, description.value, tags);

--- a/bot/src/mcp/servers/reminders.ts
+++ b/bot/src/mcp/servers/reminders.ts
@@ -56,7 +56,7 @@ let tz: string;
 export const reminderServer: McpServerDefinition = {
   serverName: 'signal-bot-reminders',
   configKey: 'reminders',
-  entrypoint: 'mcp/servers/reminders',
+  entrypoint: 'reminders',
   tools: TOOLS,
   envMapping: { DB_PATH: 'dbPath', MCP_GROUP_ID: 'groupId', MCP_SENDER: 'sender', TZ: 'timezone' },
   handlers: {
@@ -80,9 +80,8 @@ export const reminderServer: McpServerDefinition = {
     },
 
     list_reminders() {
-      if (!groupId) {
-        return ok('No group context available.');
-      }
+      const groupErr = requireGroupId(groupId);
+      if (groupErr) return groupErr;
 
       const reminders = store.listPending(groupId);
       if (reminders.length === 0) {

--- a/bot/src/mcp/servers/signal.ts
+++ b/bot/src/mcp/servers/signal.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { readStorageEnv } from '../env';
 import { catchErrors, error, ok } from '../result';
 import { runServer } from '../runServer';
 import type { McpServerDefinition } from '../types';
@@ -70,7 +71,7 @@ const TOOLS = [
 export const signalServer: McpServerDefinition = {
   serverName: 'signal-bot-signal',
   configKey: 'signal',
-  entrypoint: 'mcp/servers/signal',
+  entrypoint: 'signal',
   tools: TOOLS,
   envMapping: { SIGNAL_CLI_URL: 'signalCliUrl', SIGNAL_ACCOUNT: 'botPhoneNumber', MCP_GROUP_ID: 'groupId' },
   handlers: {
@@ -132,9 +133,10 @@ export const signalServer: McpServerDefinition = {
     },
   },
   onInit() {
+    const env = readStorageEnv();
     signalCliUrl = process.env.SIGNAL_CLI_URL || '';
     signalAccount = process.env.SIGNAL_ACCOUNT || '';
-    groupId = process.env.MCP_GROUP_ID || '';
+    groupId = env.groupId;
     console.error(`Signal MCP server started (group: ${groupId})`);
   },
 };

--- a/bot/src/mcp/servers/sourceCode.ts
+++ b/bot/src/mcp/servers/sourceCode.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { error as errorResult, ok } from '../result';
+import { catchErrors, error, ok } from '../result';
 import { runServer } from '../runServer';
 import type { McpServerDefinition } from '../types';
 import { requireString } from '../validate';
@@ -171,13 +171,13 @@ function searchRecursive(
 export const sourceCodeServer: McpServerDefinition = {
   serverName: 'signal-bot-sourcecode',
   configKey: 'sourcecode',
-  entrypoint: 'mcp/servers/sourceCode',
+  entrypoint: 'sourceCode',
   tools: TOOLS,
   envMapping: { SOURCE_ROOT: 'sourceRoot' },
   handlers: {
     list_files(args) {
       if (!sourceRoot) {
-        return errorResult('SOURCE_ROOT not configured.');
+        return error('SOURCE_ROOT not configured.');
       }
 
       const relativePath = (args.path as string) || '.';
@@ -185,28 +185,30 @@ export const sourceCodeServer: McpServerDefinition = {
 
       const resolved = resolveSafePath(relativePath);
       if (!resolved) {
-        return errorResult('Invalid path.');
+        return error('Invalid path.');
       }
 
-      try {
-        if (!fs.statSync(resolved).isDirectory()) {
-          return errorResult(`Directory not found: ${relativePath}`);
+      return catchErrors(() => {
+        try {
+          if (!fs.statSync(resolved).isDirectory()) {
+            return error(`Directory not found: ${relativePath}`);
+          }
+        } catch {
+          return error(`Directory not found: ${relativePath}`);
         }
-      } catch {
-        return errorResult(`Directory not found: ${relativePath}`);
-      }
 
-      const files = listFilesInDir(resolved, recursive, sourceRoot);
-      if (files.length === 0) {
-        return ok('No files found.');
-      }
+        const files = listFilesInDir(resolved, recursive, sourceRoot);
+        if (files.length === 0) {
+          return ok('No files found.');
+        }
 
-      return ok(files.join('\n'));
+        return ok(files.join('\n'));
+      }, 'Failed to list files');
     },
 
     read_file(args) {
       if (!sourceRoot) {
-        return errorResult('SOURCE_ROOT not configured.');
+        return error('SOURCE_ROOT not configured.');
       }
 
       const filePath = requireString(args, 'path');
@@ -214,31 +216,33 @@ export const sourceCodeServer: McpServerDefinition = {
 
       const resolved = resolveSafePath(filePath.value);
       if (!resolved) {
-        return errorResult('Invalid path.');
+        return error('Invalid path.');
       }
 
-      let stat: fs.Stats;
-      try {
-        stat = fs.statSync(resolved);
-      } catch {
-        return errorResult(`File not found: ${filePath.value}`);
-      }
-      if (!stat.isFile()) {
-        return errorResult(`File not found: ${filePath.value}`);
-      }
+      return catchErrors(() => {
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(resolved);
+        } catch {
+          return error(`File not found: ${filePath.value}`);
+        }
+        if (!stat.isFile()) {
+          return error(`File not found: ${filePath.value}`);
+        }
 
-      if (stat.size > MAX_FILE_SIZE) {
-        const content = fs.readFileSync(resolved, 'utf-8').substring(0, MAX_FILE_SIZE);
-        return ok(`${content}\n\n[Truncated — file is ${stat.size} bytes, showing first ${MAX_FILE_SIZE} bytes]`);
-      }
+        if (stat.size > MAX_FILE_SIZE) {
+          const content = fs.readFileSync(resolved, 'utf-8').substring(0, MAX_FILE_SIZE);
+          return ok(`${content}\n\n[Truncated — file is ${stat.size} bytes, showing first ${MAX_FILE_SIZE} bytes]`);
+        }
 
-      const content = fs.readFileSync(resolved, 'utf-8');
-      return ok(content);
+        const content = fs.readFileSync(resolved, 'utf-8');
+        return ok(content);
+      }, 'Failed to read file');
     },
 
     search_code(args) {
       if (!sourceRoot) {
-        return errorResult('SOURCE_ROOT not configured.');
+        return error('SOURCE_ROOT not configured.');
       }
 
       const pattern = requireString(args, 'pattern');
@@ -248,35 +252,37 @@ export const sourceCodeServer: McpServerDefinition = {
       try {
         regex = new RegExp(pattern.value, 'i');
       } catch {
-        return errorResult(`Invalid regex pattern: ${pattern.value}`);
+        return error(`Invalid regex pattern: ${pattern.value}`);
       }
 
       const relativePath = (args.path as string) || '.';
       const resolved = resolveSafePath(relativePath);
       if (!resolved) {
-        return errorResult('Invalid path.');
+        return error('Invalid path.');
       }
 
-      let extFilter: string | null = null;
-      if (args.filePattern && typeof args.filePattern === 'string') {
-        const fp = args.filePattern;
-        extFilter = fp.startsWith('*') ? fp.substring(1) : fp;
-      }
+      return catchErrors(() => {
+        let extFilter: string | null = null;
+        if (args.filePattern && typeof args.filePattern === 'string') {
+          const fp = args.filePattern;
+          extFilter = fp.startsWith('*') ? fp.substring(1) : fp;
+        }
 
-      const results: Array<{ file: string; line: number; text: string }> = [];
-      searchRecursive(resolved, regex, sourceRoot, extFilter, results);
+        const results: Array<{ file: string; line: number; text: string }> = [];
+        searchRecursive(resolved, regex, sourceRoot, extFilter, results);
 
-      if (results.length === 0) {
-        return ok(`No matches found for pattern: ${pattern.value}`);
-      }
+        if (results.length === 0) {
+          return ok(`No matches found for pattern: ${pattern.value}`);
+        }
 
-      const lines = results.map(r => `${r.file}:${r.line}: ${r.text.trim()}`);
-      let text = lines.join('\n');
-      if (results.length >= MAX_SEARCH_MATCHES) {
-        text += `\n\n[Results capped at ${MAX_SEARCH_MATCHES} matches]`;
-      }
+        const lines = results.map(r => `${r.file}:${r.line}: ${r.text.trim()}`);
+        let text = lines.join('\n');
+        if (results.length >= MAX_SEARCH_MATCHES) {
+          text += `\n\n[Results capped at ${MAX_SEARCH_MATCHES} matches]`;
+        }
 
-      return ok(text);
+        return ok(text);
+      }, 'Failed to search code');
     },
   },
   onInit() {

--- a/bot/src/mcp/servers/weather.ts
+++ b/bot/src/mcp/servers/weather.ts
@@ -2,7 +2,7 @@ import { readTimezone } from '../env';
 import { catchErrors, error, ok } from '../result';
 import { runServer } from '../runServer';
 import type { McpServerDefinition } from '../types';
-import { requireString } from '../validate';
+import { requireString, type StringResult } from '../validate';
 
 const BOM_BASE_URL = 'https://api.weather.bom.gov.au/v1';
 
@@ -88,11 +88,11 @@ function trimGeohash(geohash: string): string {
   return geohash.substring(0, 6);
 }
 
-function requireGeohash(args: Record<string, unknown>) {
+function requireGeohash(args: Record<string, unknown>): StringResult {
   const geohash = requireString(args, 'geohash');
   if (geohash.error) return geohash;
   if (geohash.value.length < 6) {
-    return { error: error('Missing or invalid geohash (need at least 6 characters).'), value: undefined as never };
+    return { error: error('Missing or invalid geohash (need at least 6 characters).') };
   }
   return geohash;
 }
@@ -100,7 +100,7 @@ function requireGeohash(args: Record<string, unknown>) {
 export const weatherServer: McpServerDefinition = {
   serverName: 'signal-bot-weather',
   configKey: 'weather',
-  entrypoint: 'mcp/servers/weather',
+  entrypoint: 'weather',
   tools: TOOLS,
   envMapping: { TZ: 'timezone' },
   handlers: {

--- a/bot/src/mcp/validate.ts
+++ b/bot/src/mcp/validate.ts
@@ -1,7 +1,7 @@
 import { error } from './result';
 import type { ToolResult } from './types';
 
-type StringResult = { value: string; error?: undefined } | { value?: undefined; error: ToolResult };
+export type StringResult = { value: string; error?: undefined } | { value?: undefined; error: ToolResult };
 type NumberResult = { value: number; error?: undefined } | { value?: undefined; error: ToolResult };
 
 export function requireString(args: Record<string, unknown>, name: string): StringResult {

--- a/bot/tests/claudeClient.test.ts
+++ b/bot/tests/claudeClient.test.ts
@@ -466,7 +466,7 @@ describe('ClaudeCLIClient', () => {
       expect(['node', 'npx']).toContain(mcpConfig.mcpServers.dossiers.command);
       expect(mcpConfig.mcpServers.dossiers.env.DB_PATH).toBe('/tmp/test.db');
       expect(mcpConfig.mcpServers.dossiers.env.MCP_GROUP_ID).toBe('test-group');
-      expect(mcpConfig.mcpServers.dossiers.env.MCP_SENDER).toBe('+61400000000');
+      expect(mcpConfig.mcpServers.dossiers.env.MCP_SENDER).toBeUndefined();
     });
 
     it('should detect when messages were sent via MCP signal tool', async () => {


### PR DESCRIPTION
## Summary
- Simplify `entrypoint` field across all MCP servers from `'mcp/servers/X'` to just `'X'`, updating registry.ts to use it directly
- Standardize groupId validation: `list_reminders` and `list_personas` now use `requireGroupId()` like all other list handlers
- Wrap `sourceCode.ts` handlers in `catchErrors()` for consistent error handling
- Replace raw `as string` casts with `optionalString()` in dossiers.ts, personas.ts; use `Array.isArray()` for labels in github.ts
- Remove unused `MCP_SENDER` from dossiers.ts envMapping
- Use `readStorageEnv()` in github.ts and signal.ts for shared env vars (MCP_SENDER, MCP_GROUP_ID)
- Fix `requireGeohash` return type in weather.ts using exported `StringResult` type
- Remove `errorResult` alias in sourceCode.ts

## Test plan
- [x] All 623 tests pass
- [x] Biome lint/format passes on all changed files
- [x] Registry test confirms entrypoint resolution still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)