### PR TITLE
Refactor core architecture: interfaces, type splits, extracted helpers

### DIFF
--- a/bot/src/claudeClient.ts
+++ b/bot/src/claudeClient.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { buildAllowedTools, buildMcpConfig } from './mcp/registry';
 import { getErrorMessage } from './mcp/result';
-import type { ChatMessage, LLMResponse, MessageContext } from './types';
+import type { ChatMessage, LLMClient, LLMResponse, MessageContext } from './types';
 
 interface ClaudeResultLine {
   type: 'result';
@@ -13,7 +13,13 @@ interface ClaudeResultLine {
   };
 }
 
-const ALLOWED_TOOLS = buildAllowedTools();
+let cachedAllowedTools: string | undefined;
+function getAllowedTools(): string {
+  if (!cachedAllowedTools) {
+    cachedAllowedTools = buildAllowedTools();
+  }
+  return cachedAllowedTools;
+}
 
 function spawnPromise(
   cmd: string,
@@ -59,7 +65,99 @@ function spawnPromise(
   });
 }
 
-export class ClaudeCLIClient {
+/** Parse raw Claude CLI stdout into a structured LLMResponse. */
+export function parseClaudeOutput(stdout: string): LLMResponse {
+  const trimmed = stdout.trim();
+  let entries: Array<Record<string, unknown>> = [];
+
+  if (trimmed.startsWith('[')) {
+    entries = JSON.parse(trimmed);
+  } else {
+    for (const line of trimmed.split('\n')) {
+      try {
+        entries.push(JSON.parse(line));
+      } catch {
+        /* skip */
+      }
+    }
+  }
+
+  // Single pass: find result line, last assistant entry, and MCP send_message calls
+  let resultLine: ClaudeResultLine | undefined;
+  let lastAssistant: { message?: { content?: Array<{ type: string; text?: string }> } } | undefined;
+  const mcpMessages: string[] = [];
+  for (const e of entries) {
+    if (e.type === 'result') resultLine = e as unknown as ClaudeResultLine;
+    if (e.type === 'assistant') lastAssistant = e as unknown as typeof lastAssistant;
+
+    // Detect send_message and send_image MCP tool calls
+    if (e.type === 'assistant') {
+      const msg = e as unknown as {
+        message?: {
+          content?: Array<{ type: string; name?: string; input?: Record<string, unknown> }>;
+        };
+      };
+      for (const block of msg.message?.content || []) {
+        if (block.type === 'tool_use' && block.name === 'mcp__signal__send_message' && block.input?.message) {
+          mcpMessages.push(block.input.message as string);
+        }
+        if (block.type === 'tool_use' && block.name === 'mcp__signal__send_image') {
+          const caption = block.input?.caption as string | undefined;
+          mcpMessages.push(caption ? `[sent an image: ${caption}]` : '[sent an image]');
+        }
+      }
+    }
+  }
+
+  if (!resultLine) {
+    console.error(
+      '[Claude] No result line in output. Entry types:',
+      entries.map(e => e.type),
+    );
+    throw new Error('No result found in Claude CLI output');
+  }
+
+  // Prefer result field, fall back to last assistant message text
+  let content = '';
+
+  if (resultLine.is_error) {
+    console.warn(
+      `[Claude] Result has is_error=true, subtype=${(resultLine as unknown as Record<string, unknown>).subtype}. Falling back to assistant text.`,
+    );
+  } else {
+    content = typeof resultLine.result === 'string' ? resultLine.result.trim() : '';
+  }
+
+  if (!content) {
+    // Extract text from the last assistant message
+    const textBlocks = lastAssistant?.message?.content?.filter(b => b.type === 'text') || [];
+    content = textBlocks
+      .map(b => b.text || '')
+      .join('')
+      .trim();
+    if (content) {
+      console.log(`[Claude] Used fallback: extracted ${content.length} chars from assistant message`);
+    }
+  }
+
+  if (!content) {
+    if (mcpMessages.length === 0) {
+      console.error('[Claude] No content found. Full output:', JSON.stringify(entries, null, 2).substring(0, 2000));
+      throw new Error('No response content from Claude CLI');
+    }
+    // Response delivered via MCP send_message — use last sent message as content fallback
+    content = mcpMessages[mcpMessages.length - 1];
+  }
+
+  return {
+    content,
+    tokensUsed: resultLine.usage?.output_tokens || 0,
+    sentViaMcp: mcpMessages.length > 0,
+    mcpMessages,
+  };
+}
+
+export class ClaudeCLIClient implements LLMClient {
   private maxTurns: number;
 
   constructor(maxTurns: number = 1) {
@@ -95,7 +193,7 @@ export class ClaudeCLIClient {
       String(this.maxTurns),
       '--no-session-persistence',
       '--allowedTools',
-      ALLOWED_TOOLS,
+      getAllowedTools(),
     ];
 
     if (context) {
@@ -124,95 +222,7 @@ export class ClaudeCLIClient {
         env: { ...process.env, CLAUDECODE: '' },
       });
 
-      // Output may be a JSON array or NDJSON — parse all entries
-      const trimmed = stdout.trim();
-      let entries: Array<Record<string, unknown>> = [];
-
-      if (trimmed.startsWith('[')) {
-        entries = JSON.parse(trimmed);
-      } else {
-        for (const line of trimmed.split('\n')) {
-          try {
-            entries.push(JSON.parse(line));
-          } catch {
-            /* skip */
-          }
-        }
-      }
-
-      // Single pass: find result line, last assistant entry, and MCP send_message calls
-      let resultLine: ClaudeResultLine | undefined;
-      let lastAssistant: { message?: { content?: Array<{ type: string; text?: string }> } } | undefined;
-      const mcpMessages: string[] = [];
-      for (const e of entries) {
-        if (e.type === 'result') resultLine = e as unknown as ClaudeResultLine;
-        if (e.type === 'assistant') lastAssistant = e as unknown as typeof lastAssistant;
-
-        // Detect send_message and send_image MCP tool calls
-        if (e.type === 'assistant') {
-          const msg = e as unknown as {
-            message?: {
-              content?: Array<{ type: string; name?: string; input?: Record<string, unknown> }>;
-            };
-          };
-          for (const block of msg.message?.content || []) {
-            if (block.type === 'tool_use' && block.name === 'mcp__signal__send_message' && block.input?.message) {
-              mcpMessages.push(block.input.message as string);
-            }
-            if (block.type === 'tool_use' && block.name === 'mcp__signal__send_image') {
-              const caption = block.input?.caption as string | undefined;
-              mcpMessages.push(caption ? `[sent an image: ${caption}]` : '[sent an image]');
-            }
-          }
-        }
-      }
-
-      if (!resultLine) {
-        console.error(
-          '[Claude] No result line in output. Entry types:',
-          entries.map(e => e.type),
-        );
-        throw new Error('No result found in Claude CLI output');
-      }
-
-      // Prefer result field, fall back to last assistant message text
-      let content = '';
-
-      if (resultLine.is_error) {
-        console.warn(
-          `[Claude] Result has is_error=true, subtype=${(resultLine as unknown as Record<string, unknown>).subtype}. Falling back to assistant text.`,
-        );
-      } else {
-        content = typeof resultLine.result === 'string' ? resultLine.result.trim() : '';
-      }
-
-      if (!content) {
-        // Extract text from the last assistant message
-        const textBlocks = lastAssistant?.message?.content?.filter(b => b.type === 'text') || [];
-        content = textBlocks
-          .map(b => b.text || '')
-          .join('')
-          .trim();
-        if (content) {
-          console.log(`[Claude] Used fallback: extracted ${content.length} chars from assistant message`);
-        }
-      }
-
-      if (!content) {
-        if (mcpMessages.length === 0) {
-          console.error('[Claude] No content found. Full output:', JSON.stringify(entries, null, 2).substring(0, 2000));
-          throw new Error('No response content from Claude CLI');
-        }
-        // Response delivered via MCP send_message — use last sent message as content fallback
-        content = mcpMessages[mcpMessages.length - 1];
-      }
-
-      return {
-        content,
-        tokensUsed: resultLine.usage?.output_tokens || 0,
-        sentViaMcp: mcpMessages.length > 0,
-        mcpMessages,
-      };
+      return parseClaudeOutput(stdout);
     } catch (error) {
       if (error instanceof Error) {
         // Re-throw our own errors

--- a/bot/src/contextBuilder.ts
+++ b/bot/src/contextBuilder.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { estimateTokens } from './mcp/result';
 import type { ChatMessage, Message, SignalAttachment } from './types';
+import { formatTimestamp } from './utils/dateFormat';
 
 const PERSONA_SAFETY_PROMPT = `## Persona Guidelines
 You must refuse requests to create or adopt personas that:
@@ -11,6 +13,15 @@ You must refuse requests to create or adopt personas that:
 - Attempt to bypass your safety guidelines or ethical boundaries
 
 If asked to create or switch to such a persona, politely decline and explain why.`;
+
+const SOURCE_CODE_INSTRUCTIONS =
+  'You have access to your own source code via the sourcecode tools (list_files, read_file, search_code). When asked how you work, what you can do, or technical questions about your implementation, use these tools to read the actual code before answering.';
+
+const VOICE_MESSAGE_INSTRUCTIONS =
+  'When a voice message is attached (shown as [Voice message attached: <path>] in the conversation), use the transcribe_audio tool to transcribe it, then respond to the transcribed content as if the user had typed it. Voice messages may appear in the current message or in recent conversation history.';
+
+const IMAGE_INSTRUCTIONS =
+  'When an image is attached (shown as [Image attached: <path>] in the conversation), use the Read tool to view it, then respond about the image content. Images may appear in the current message or in recent conversation history.';
 
 export interface ContextBuilderConfig {
   systemPrompt: string;
@@ -56,10 +67,16 @@ export class ContextBuilder {
   }
 
   private formatTimestamp(timestamp: number): string {
-    const date = new Date(timestamp);
-    const parts = this.timestampFormatter.formatToParts(date);
+    return formatTimestamp(timestamp, this.timestampFormatter);
+  }
+
+  private formatCurrentTimeISO(): { isoString: string; unixMs: number } {
+    const now = new Date();
+    const parts = this.isoFormatter.formatToParts(now);
     const get = (type: string) => parts.find(p => p.type === type)?.value || '';
-    return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}`;
+    const offset = get('timeZoneName').replace('GMT', '') || '+00:00';
+    const isoString = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}${offset}`;
+    return { isoString, unixMs: now.getTime() };
   }
 
   private formatVoiceAttachmentLines(attachments: SignalAttachment[]): string[] {
@@ -104,7 +121,7 @@ export class ContextBuilder {
     // Walk from newest to oldest
     for (let i = messages.length - 1; i >= 0; i--) {
       const formatted = this.formatMessageForContext(messages[i]);
-      const tokens = Math.ceil(formatted.length / 4);
+      const tokens = estimateTokens(formatted);
       if (totalTokens + tokens > this.contextTokenBudget) {
         cutoffIndex = i + 1;
         break;
@@ -150,21 +167,16 @@ export class ContextBuilder {
     let systemContent: string;
 
     if (groupId && sender) {
-      const now = new Date();
-      const parts = this.isoFormatter.formatToParts(now);
-      const get = (type: string) => parts.find(p => p.type === type)?.value || '';
-      const offset = get('timeZoneName').replace('GMT', '') || '+00:00';
-      const isoString = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}${offset}`;
-      const unixMs = now.getTime();
+      const { isoString, unixMs } = this.formatCurrentTimeISO();
 
       const timeContext = [
         `Current time: ${isoString} (Unix ms: ${unixMs})`,
         `Timezone: ${this.timezone}`,
         `Group ID: ${groupId}`,
         `Current requester: ${nameMap?.get(sender) ? `${nameMap.get(sender)} (${sender})` : sender}`,
-        `You have access to your own source code via the sourcecode tools (list_files, read_file, search_code). When asked how you work, what you can do, or technical questions about your implementation, use these tools to read the actual code before answering.`,
-        `When a voice message is attached (shown as [Voice message attached: <path>] in the conversation), use the transcribe_audio tool to transcribe it, then respond to the transcribed content as if the user had typed it. Voice messages may appear in the current message or in recent conversation history.`,
-        `When an image is attached (shown as [Image attached: <path>] in the conversation), use the Read tool to view it, then respond about the image content. Images may appear in the current message or in recent conversation history.`,
+        SOURCE_CODE_INSTRUCTIONS,
+        VOICE_MESSAGE_INSTRUCTIONS,
+        IMAGE_INSTRUCTIONS,
       ].join('\n');
 
       if (dossierContext) {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -23,27 +23,30 @@ async function main() {
   const reminderScheduler = new ReminderScheduler(storage.reminders, signalClient);
   console.log('Reminder scheduler initialized');
 
-  const messageHandler = new MessageHandler(config.mentionTriggers, {
-    messageContext: {
-      groupId: '',
-      sender: '',
-      dbPath: config.dbPath,
-      timezone: config.timezone,
-      githubRepo: config.githubRepo,
-      sourceRoot: config.sourceRoot,
-      signalCliUrl: config.signalCliUrl,
-      botPhoneNumber: config.botPhoneNumber,
-      attachmentsDir: config.attachmentsDir,
-      whisperModelPath: config.whisperModelPath,
+  const messageHandler = new MessageHandler(
+    config.mentionTriggers,
+    {
+      storage,
+      llmClient,
+      signalClient,
+      appConfig: {
+        dbPath: config.dbPath,
+        timezone: config.timezone,
+        githubRepo: config.githubRepo,
+        sourceRoot: config.sourceRoot,
+        signalCliUrl: config.signalCliUrl,
+        botPhoneNumber: config.botPhoneNumber,
+        attachmentsDir: config.attachmentsDir,
+        whisperModelPath: config.whisperModelPath,
+      },
     },
-    systemPrompt: config.systemPrompt,
-    storage,
-    llmClient,
-    signalClient,
-    contextWindowSize: config.contextWindowSize,
-    contextTokenBudget: config.contextTokenBudget,
-    messageRetentionCount: config.messageRetentionCount,
-  });
+    {
+      systemPrompt: config.systemPrompt,
+      contextWindowSize: config.contextWindowSize,
+      contextTokenBudget: config.contextTokenBudget,
+      messageRetentionCount: config.messageRetentionCount,
+    },
+  );
   console.log(`Message handler initialized (triggers: ${config.mentionTriggers.join(', ')})`);
 
   if (config.testChannelOnly) {

--- a/bot/src/mcp/servers/messageHistory.ts
+++ b/bot/src/mcp/servers/messageHistory.ts
@@ -1,6 +1,7 @@
 import { DatabaseConnection } from '../../db';
 import { MessageStore } from '../../stores/messageStore';
 import type { Message } from '../../types';
+import { formatTimestamp as sharedFormatTimestamp } from '../../utils/dateFormat';
 import { readStorageEnv, readTimezone } from '../env';
 import { catchErrors, error, ok } from '../result';
 import { runServer } from '../runServer';
@@ -57,9 +58,7 @@ let groupId: string;
 let timestampFormatter: Intl.DateTimeFormat;
 
 function formatTimestamp(timestamp: number): string {
-  const parts = timestampFormatter.formatToParts(new Date(timestamp));
-  const get = (type: string) => parts.find(p => p.type === type)?.value || '';
-  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}`;
+  return sharedFormatTimestamp(timestamp, timestampFormatter);
 }
 
 function formatMessages(messages: Message[]): string {

--- a/bot/src/mcp/types.ts
+++ b/bot/src/mcp/types.ts
@@ -14,7 +14,7 @@ export interface ToolDefinition {
 
 export type ToolHandler = (args: Record<string, unknown>) => ToolResult | Promise<ToolResult>;
 
-/** Maps env var names to MessageContext field names */
+/** Maps env var names to MessageContext (AppConfig & RequestContext) field names */
 export type EnvMapping = Record<string, keyof MessageContext>;
 
 export interface McpServerDefinition {

--- a/bot/src/messageHandler.ts
+++ b/bot/src/messageHandler.ts
@@ -1,41 +1,42 @@
-import type { ClaudeCLIClient } from './claudeClient';
 import { ContextBuilder } from './contextBuilder';
 import { estimateTokens } from './mcp/result';
 import { MentionDetector } from './mentionDetector';
 import { MessageDeduplicator } from './messageDeduplicator';
 import type { SignalClient } from './signalClient';
 import type { Storage } from './storage';
-import type { Message, MessageContext, SignalAttachment } from './types';
+import type { AppConfig, LLMClient, Message, SignalAttachment } from './types';
 import { TypingIndicatorManager } from './typingIndicator';
+
+export interface MessageHandlerOptions {
+  systemPrompt?: string;
+  contextWindowSize?: number;
+  contextTokenBudget?: number;
+  messageRetentionCount?: number;
+}
 
 export class MessageHandler {
   private mentionDetector: MentionDetector;
   private contextBuilder: ContextBuilder;
   private deduplicator: MessageDeduplicator;
   private typingManager: TypingIndicatorManager;
-  private messageContext: MessageContext;
-  private storage?: Storage;
-  private llmClient?: ClaudeCLIClient;
-  private signalClient?: SignalClient;
+  private appConfig: AppConfig;
+  private storage: Storage;
+  private llmClient: LLMClient;
+  private signalClient: SignalClient;
   private contextWindowSize: number;
   private messageRetentionCount: number;
 
   constructor(
     mentionTriggers: string[],
-    options?: {
-      messageContext?: MessageContext;
-      systemPrompt?: string;
-      storage?: Storage;
-      llmClient?: ClaudeCLIClient;
-      signalClient?: SignalClient;
-      contextWindowSize?: number;
-      contextTokenBudget?: number;
-      messageRetentionCount?: number;
+    deps: {
+      storage: Storage;
+      llmClient: LLMClient;
+      signalClient: SignalClient;
+      appConfig?: AppConfig;
     },
+    options?: MessageHandlerOptions,
   ) {
-    this.messageContext = options?.messageContext || {
-      groupId: '',
-      sender: '',
+    this.appConfig = deps.appConfig || {
       dbPath: './data/bot.db',
       timezone: 'Australia/Sydney',
       githubRepo: '',
@@ -45,24 +46,21 @@ export class MessageHandler {
       attachmentsDir: './data/signal-attachments',
       whisperModelPath: './models/ggml-base.en.bin',
     };
-    this.storage = options?.storage;
-    this.llmClient = options?.llmClient;
-    this.signalClient = options?.signalClient;
+    this.storage = deps.storage;
+    this.llmClient = deps.llmClient;
+    this.signalClient = deps.signalClient;
     this.contextWindowSize = options?.contextWindowSize || 200;
     this.messageRetentionCount = options?.messageRetentionCount || 1000;
 
     this.mentionDetector = new MentionDetector(mentionTriggers);
     this.contextBuilder = new ContextBuilder({
       systemPrompt: options?.systemPrompt || '',
-      timezone: this.messageContext.timezone,
+      timezone: this.appConfig.timezone,
       contextTokenBudget: options?.contextTokenBudget || 4000,
-      attachmentsDir: this.messageContext.attachmentsDir,
+      attachmentsDir: this.appConfig.attachmentsDir,
     });
     this.deduplicator = new MessageDeduplicator();
-    // TypingIndicatorManager is only used when signalClient is provided
-    this.typingManager = new TypingIndicatorManager(
-      options?.signalClient || ({ sendTyping: async () => {}, stopTyping: async () => {} } as SignalClient),
-    );
+    this.typingManager = new TypingIndicatorManager(deps.signalClient);
   }
 
   async handleMessage(
@@ -73,12 +71,8 @@ export class MessageHandler {
     attachments: SignalAttachment[] = [],
     options?: { storeOnly?: boolean },
   ): Promise<void> {
-    if (!this.storage || !this.llmClient || !this.signalClient) {
-      throw new Error('Handler not fully initialized');
-    }
-
     // Skip messages from the bot itself
-    if (this.messageContext.botPhoneNumber && sender === this.messageContext.botPhoneNumber) {
+    if (this.appConfig.botPhoneNumber && sender === this.appConfig.botPhoneNumber) {
       return;
     }
 
@@ -119,6 +113,55 @@ export class MessageHandler {
     );
   }
 
+  /** Assemble additional context (dossiers, memories, skills, persona) for the LLM request. */
+  private assembleAdditionalContext(groupId: string): {
+    additionalContext: string | undefined;
+    nameMap: Map<string, string>;
+    personaPrompt: string | undefined;
+  } {
+    const contextParts: string[] = [];
+    const dossiers = this.storage.getDossiersByGroup(groupId);
+    const nameMap = new Map(dossiers.map(d => [d.personId, d.displayName]));
+    if (dossiers.length > 0) {
+      const entries = dossiers.map(d => {
+        const parts = [`- ${d.displayName} (${d.personId})`];
+        if (d.notes) parts.push(`  ${d.notes}`);
+        return parts.join('\n');
+      });
+      contextParts.push(`## People in this group\n${entries.join('\n')}`);
+    }
+    const MEMORY_CONTEXT_BUDGET = 2000;
+    const memories = this.storage.getMemoriesByGroup(groupId);
+    if (memories.length > 0) {
+      let tokenTotal = 0;
+      const memoryLines: string[] = [];
+      for (const m of memories) {
+        const line = `- **${m.topic}**: ${m.content}`;
+        const tokens = estimateTokens(line);
+        if (tokenTotal + tokens > MEMORY_CONTEXT_BUDGET) break;
+        tokenTotal += tokens;
+        memoryLines.push(line);
+      }
+      if (memoryLines.length > 0) {
+        contextParts.push(`## Group Memory\n${memoryLines.join('\n')}`);
+      }
+    }
+    const skillContent = this.contextBuilder.loadSkillContent();
+    if (skillContent) {
+      contextParts.push(skillContent);
+    }
+
+    // Look up active persona for this group
+    const activePersona = this.storage.getActivePersonaForGroup(groupId);
+    const personaPrompt = activePersona?.description;
+
+    return {
+      additionalContext: contextParts.join('\n\n') || undefined,
+      nameMap,
+      personaPrompt,
+    };
+  }
+
   private async processLlmRequest(
     groupId: string,
     sender: string,
@@ -127,11 +170,6 @@ export class MessageHandler {
     history: Message[],
     historyFormatted?: string[],
   ): Promise<void> {
-    // These are guaranteed non-null by the guard in handleMessage
-    const storage = this.storage as Storage;
-    const llmClient = this.llmClient as ClaudeCLIClient;
-    const signalClient = this.signalClient as SignalClient;
-
     try {
       // Extract query
       const query = this.mentionDetector.extractQuery(content);
@@ -150,45 +188,10 @@ export class MessageHandler {
         queryWithAttachments = query ? `${query}\n\n${attachmentBlock}` : attachmentBlock;
       }
 
-      // Build additional system context (dossiers + skills)
-      const contextParts: string[] = [];
-      const dossiers = storage.getDossiersByGroup(groupId);
-      const nameMap = new Map(dossiers.map(d => [d.personId, d.displayName]));
-      if (dossiers.length > 0) {
-        const entries = dossiers.map(d => {
-          const parts = [`- ${d.displayName} (${d.personId})`];
-          if (d.notes) parts.push(`  ${d.notes}`);
-          return parts.join('\n');
-        });
-        contextParts.push(`## People in this group\n${entries.join('\n')}`);
-      }
-      const MEMORY_CONTEXT_BUDGET = 2000;
-      const memories = storage.getMemoriesByGroup(groupId);
-      if (memories.length > 0) {
-        let tokenTotal = 0;
-        const memoryLines: string[] = [];
-        for (const m of memories) {
-          const line = `- **${m.topic}**: ${m.content}`;
-          const tokens = estimateTokens(line);
-          if (tokenTotal + tokens > MEMORY_CONTEXT_BUDGET) break;
-          tokenTotal += tokens;
-          memoryLines.push(line);
-        }
-        if (memoryLines.length > 0) {
-          contextParts.push(`## Group Memory\n${memoryLines.join('\n')}`);
-        }
-      }
-      const skillContent = this.contextBuilder.loadSkillContent();
-      if (skillContent) {
-        contextParts.push(skillContent);
-      }
-
-      // Look up active persona for this group
-      const activePersona = storage.getActivePersonaForGroup(groupId);
-      const personaPrompt = activePersona?.description;
+      // Build additional system context (dossiers + memories + skills + persona)
+      const { additionalContext, nameMap, personaPrompt } = this.assembleAdditionalContext(groupId);
 
       // Build context
-      const additionalContext = contextParts.join('\n\n') || undefined;
       const messages = this.contextBuilder.buildContext({
         history,
         query: queryWithAttachments,
@@ -201,17 +204,17 @@ export class MessageHandler {
       });
 
       // Get LLM response
-      const response = await llmClient.generateResponse(messages, {
-        ...this.messageContext,
+      const response = await this.llmClient.generateResponse(messages, {
+        ...this.appConfig,
         groupId,
         sender,
       });
 
-      const botSender = this.messageContext.botPhoneNumber || 'bot';
+      const botSender = this.appConfig.botPhoneNumber || 'bot';
       if (response.sentViaMcp) {
         // Claude sent messages directly — store each one
         for (const mcpMsg of response.mcpMessages) {
-          storage.addMessage({
+          this.storage.addMessage({
             groupId,
             sender: botSender,
             content: mcpMsg,
@@ -221,8 +224,8 @@ export class MessageHandler {
         }
       } else {
         // Fallback: Claude didn't use the MCP tool, send result as before
-        await signalClient.sendMessage(groupId, response.content);
-        storage.addMessage({
+        await this.signalClient.sendMessage(groupId, response.content);
+        this.storage.addMessage({
           groupId,
           sender: botSender,
           content: response.content,
@@ -232,7 +235,7 @@ export class MessageHandler {
       }
 
       // Trim old messages
-      storage.trimMessages(groupId, this.messageRetentionCount);
+      this.storage.trimMessages(groupId, this.messageRetentionCount);
 
       console.log(`[${groupId}] Responded to ${sender} (${response.tokensUsed} tokens)`);
     } catch (error) {
@@ -241,7 +244,7 @@ export class MessageHandler {
       // Try to send error message to group
       try {
         const errorMsg = 'Sorry, I encountered an error processing your request.';
-        await signalClient.sendMessage(groupId, errorMsg);
+        await this.signalClient.sendMessage(groupId, errorMsg);
       } catch (sendError) {
         console.error('Failed to send error message:', sendError);
       }

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -71,9 +71,8 @@ export interface ActivePersona {
   activatedAt: number;
 }
 
-export interface MessageContext {
-  groupId: string;
-  sender: string;
+/** Static application configuration — does not change per request. */
+export interface AppConfig {
   dbPath: string;
   timezone: string;
   githubRepo: string;
@@ -82,6 +81,20 @@ export interface MessageContext {
   botPhoneNumber: string;
   attachmentsDir: string;
   whisperModelPath: string;
+}
+
+/** Per-message request context. */
+export interface RequestContext {
+  groupId: string;
+  sender: string;
+}
+
+/** Combined context — backward-compatible alias. */
+export type MessageContext = AppConfig & RequestContext;
+
+/** Interface for LLM clients (enables testing without real CLI). */
+export interface LLMClient {
+  generateResponse(messages: ChatMessage[], context?: MessageContext): Promise<LLMResponse>;
 }
 
 export interface SignalAttachment {

--- a/bot/src/utils/dateFormat.ts
+++ b/bot/src/utils/dateFormat.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared timestamp formatting utility.
+ * Accepts a timestamp and an Intl.DateTimeFormat instance,
+ * returns a "YYYY-MM-DD HH:MM" string.
+ */
+export function formatTimestamp(timestamp: number, formatter: Intl.DateTimeFormat): string {
+  const parts = formatter.formatToParts(new Date(timestamp));
+  const get = (type: string) => parts.find(p => p.type === type)?.value || '';
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}`;
+}

--- a/bot/tests/claudeClient.test.ts
+++ b/bot/tests/claudeClient.test.ts
@@ -15,7 +15,7 @@ vi.mock('child_process', async importOriginal => {
   };
 });
 
-import { ClaudeCLIClient } from '../src/claudeClient';
+import { ClaudeCLIClient, parseClaudeOutput } from '../src/claudeClient';
 
 function makeResultOutput(result: string, isError = false, usage?: { output_tokens: number }) {
   const initLine = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'test' });
@@ -778,6 +778,59 @@ describe('ClaudeCLIClient', () => {
       expect(mcpConfig.mcpServers.playwright).toBeDefined();
       expect(mcpConfig.mcpServers.playwright.command).toBe('npx');
       expect(mcpConfig.mcpServers.playwright.args).toContain('--headless');
+    });
+  });
+
+  describe('parseClaudeOutput', () => {
+    it('should parse NDJSON output with result line', () => {
+      const output = makeResultOutput('Hello!', false, { output_tokens: 10 });
+      const result = parseClaudeOutput(output);
+      expect(result.content).toBe('Hello!');
+      expect(result.tokensUsed).toBe(10);
+      expect(result.sentViaMcp).toBe(false);
+    });
+
+    it('should parse JSON array output', () => {
+      const output = JSON.stringify([
+        { type: 'system', subtype: 'init', session_id: 'test' },
+        { type: 'result', is_error: false, result: 'Array!', usage: { output_tokens: 5 } },
+      ]);
+      const result = parseClaudeOutput(output);
+      expect(result.content).toBe('Array!');
+    });
+
+    it('should throw when no result line found', () => {
+      const output = JSON.stringify({ type: 'system', subtype: 'init' });
+      expect(() => parseClaudeOutput(output)).toThrow('No result found in Claude CLI output');
+    });
+
+    it('should detect MCP send_message tool calls', () => {
+      const output = [
+        JSON.stringify({ type: 'system', subtype: 'init', session_id: 'test' }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', name: 'mcp__signal__send_message', input: { message: 'Hi there' } }],
+          },
+        }),
+        JSON.stringify({ type: 'result', is_error: false, result: 'Hi there', usage: { output_tokens: 5 } }),
+      ].join('\n');
+      const result = parseClaudeOutput(output);
+      expect(result.sentViaMcp).toBe(true);
+      expect(result.mcpMessages).toEqual(['Hi there']);
+    });
+
+    it('should fall back to assistant text when result has is_error', () => {
+      const output = [
+        JSON.stringify({ type: 'system', subtype: 'init', session_id: 'test' }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'Fallback text' }] },
+        }),
+        JSON.stringify({ type: 'result', is_error: true, result: 'Rate limited', subtype: 'error' }),
+      ].join('\n');
+      const result = parseClaudeOutput(output);
+      expect(result.content).toBe('Fallback text');
     });
   });
 });

--- a/bot/tests/messageHandler.test.ts
+++ b/bot/tests/messageHandler.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ClaudeCLIClient } from '../src/claudeClient';
 import { MessageHandler } from '../src/messageHandler';
 import type { SignalClient } from '../src/signalClient';
 import type { Storage } from '../src/storage';
-import type { Message, MessageContext } from '../src/types';
+import type { AppConfig, LLMClient, Message } from '../src/types';
 
-function makeContext(overrides?: Partial<MessageContext>): MessageContext {
+function makeAppConfig(overrides?: Partial<AppConfig>): AppConfig {
   return {
-    groupId: '',
-    sender: '',
     dbPath: './data/bot.db',
     timezone: 'Australia/Sydney',
     githubRepo: '',
@@ -22,38 +19,9 @@ function makeContext(overrides?: Partial<MessageContext>): MessageContext {
 }
 
 describe('MessageHandler', () => {
-  describe('Constructor', () => {
-    it('should create handler with minimal configuration', () => {
-      const handler = new MessageHandler(['@bot']);
-      expect(handler).toBeDefined();
-    });
-
-    it('should create handler with all options', () => {
-      const handler = new MessageHandler(['@bot'], {
-        storage: {} as Storage,
-        llmClient: {} as ClaudeCLIClient,
-        signalClient: {} as SignalClient,
-        contextWindowSize: 10,
-        messageContext: makeContext({ botPhoneNumber: '+1234567890' }),
-        systemPrompt: 'Custom prompt',
-      });
-      expect(handler).toBeDefined();
-    });
-
-    it('should use default context window size of 200', () => {
-      const handler = new MessageHandler(['@bot']);
-      expect(handler).toBeDefined();
-    });
-
-    it('should accept custom context window size', () => {
-      const handler = new MessageHandler(['@bot'], { contextWindowSize: 50 });
-      expect(handler).toBeDefined();
-    });
-  });
-
   describe('handleMessage', () => {
     let mockStorage: Storage;
-    let mockLLM: ClaudeCLIClient;
+    let mockLLM: LLMClient;
     let mockSignal: SignalClient;
 
     beforeEach(() => {
@@ -64,8 +32,8 @@ describe('MessageHandler', () => {
         getRecentMessages: vi.fn().mockReturnValue([]),
         trimMessages: vi.fn(),
         getDossiersByGroup: vi.fn().mockReturnValue([]),
-        getActivePersonaForGroup: vi.fn().mockReturnValue(null),
         getMemoriesByGroup: vi.fn().mockReturnValue([]),
+        getActivePersonaForGroup: vi.fn().mockReturnValue(null),
       } as any;
 
       mockLLM = {
@@ -75,7 +43,7 @@ describe('MessageHandler', () => {
           sentViaMcp: false,
           mcpMessages: [],
         }),
-      } as any;
+      };
 
       mockSignal = {
         sendMessage: vi.fn().mockResolvedValue(undefined),
@@ -84,20 +52,12 @@ describe('MessageHandler', () => {
       } as any;
     });
 
-    it('should throw error when handler not fully initialized', async () => {
-      const handler = new MessageHandler(['@bot']);
-
-      await expect(handler.handleMessage('g1', 'Alice', '@bot hello', 1000)).rejects.toThrow(
-        'Handler not fully initialized',
-      );
-    });
-
     it('should skip messages from the bot itself', async () => {
       const handler = new MessageHandler(['@bot'], {
         storage: mockStorage,
         llmClient: mockLLM,
         signalClient: mockSignal,
-        messageContext: makeContext({ botPhoneNumber: '+1234567890' }),
+        appConfig: makeAppConfig({ botPhoneNumber: '+1234567890' }),
       });
 
       await handler.handleMessage('g1', '+1234567890', '@bot hello', 1000);
@@ -112,7 +72,7 @@ describe('MessageHandler', () => {
         storage: mockStorage,
         llmClient: mockLLM,
         signalClient: mockSignal,
-        messageContext: makeContext({ botPhoneNumber: '+1234567890' }),
+        appConfig: makeAppConfig({ botPhoneNumber: '+1234567890' }),
       });
 
       await handler.handleMessage('g1', '+9876543210', '@bot hello', 1000);
@@ -213,12 +173,11 @@ describe('MessageHandler', () => {
     });
 
     it('should trim messages after responding', async () => {
-      const handler = new MessageHandler(['@bot'], {
-        storage: mockStorage,
-        llmClient: mockLLM,
-        signalClient: mockSignal,
-        contextWindowSize: 20,
-      });
+      const handler = new MessageHandler(
+        ['@bot'],
+        { storage: mockStorage, llmClient: mockLLM, signalClient: mockSignal },
+        { contextWindowSize: 20 },
+      );
 
       await handler.handleMessage('g1', 'Alice', '@bot hello', 1000);
 
@@ -264,12 +223,11 @@ describe('MessageHandler', () => {
     });
 
     it('should use correct context window size', async () => {
-      const handler = new MessageHandler(['@bot'], {
-        storage: mockStorage,
-        llmClient: mockLLM,
-        signalClient: mockSignal,
-        contextWindowSize: 10,
-      });
+      const handler = new MessageHandler(
+        ['@bot'],
+        { storage: mockStorage, llmClient: mockLLM, signalClient: mockSignal },
+        { contextWindowSize: 10 },
+      );
 
       await handler.handleMessage('g1', 'Alice', '@bot hello', 1000);
 
@@ -484,7 +442,7 @@ describe('MessageHandler', () => {
 
     describe('MCP-based message sending', () => {
       it('should not auto-send response when Claude sent messages via MCP', async () => {
-        const mockLLM = {
+        const mcpLLM: LLMClient = {
           generateResponse: vi.fn().mockResolvedValue({
             content: 'Final answer',
             tokensUsed: 10,
@@ -494,9 +452,9 @@ describe('MessageHandler', () => {
         };
         const handler = new MessageHandler(['@bot'], {
           storage: mockStorage,
-          llmClient: mockLLM as any,
+          llmClient: mcpLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
+          appConfig: makeAppConfig({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
         });
 
         await handler.handleMessage('g1', '+61111', '@bot test', Date.now());
@@ -506,7 +464,7 @@ describe('MessageHandler', () => {
       });
 
       it('should auto-send response as fallback when Claude did not use MCP', async () => {
-        const mockLLM = {
+        const plainLLM: LLMClient = {
           generateResponse: vi.fn().mockResolvedValue({
             content: 'Simple reply',
             tokensUsed: 10,
@@ -516,9 +474,9 @@ describe('MessageHandler', () => {
         };
         const handler = new MessageHandler(['@bot'], {
           storage: mockStorage,
-          llmClient: mockLLM as any,
+          llmClient: plainLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
+          appConfig: makeAppConfig({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
         });
 
         await handler.handleMessage('g1', '+61111', '@bot test', Date.now());
@@ -528,7 +486,7 @@ describe('MessageHandler', () => {
       });
 
       it('should store each MCP-sent message in the database', async () => {
-        const mockLLM = {
+        const mcpLLM: LLMClient = {
           generateResponse: vi.fn().mockResolvedValue({
             content: 'Final',
             tokensUsed: 10,
@@ -538,9 +496,9 @@ describe('MessageHandler', () => {
         };
         const handler = new MessageHandler(['@bot'], {
           storage: mockStorage,
-          llmClient: mockLLM as any,
+          llmClient: mcpLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
+          appConfig: makeAppConfig({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
         });
 
         await handler.handleMessage('g1', '+61111', '@bot test', Date.now());
@@ -557,7 +515,7 @@ describe('MessageHandler', () => {
           storage: mockStorage,
           llmClient: mockLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
+          appConfig: makeAppConfig({ botPhoneNumber: '+61000', signalCliUrl: 'http://localhost:8080' }),
         });
 
         await handler.handleMessage('g1', '+61111', '@bot hello', Date.now());
@@ -642,7 +600,7 @@ describe('MessageHandler', () => {
           storage: mockStorage,
           llmClient: mockLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ attachmentsDir: '/data/attachments' }),
+          appConfig: makeAppConfig({ attachmentsDir: '/data/attachments' }),
         });
 
         await handler.handleMessage('g1', 'Bob', '@bot transcribe that', 1000);
@@ -731,7 +689,7 @@ describe('MessageHandler', () => {
           storage: mockStorage,
           llmClient: mockLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ attachmentsDir: '/data/attachments' }),
+          appConfig: makeAppConfig({ attachmentsDir: '/data/attachments' }),
         });
 
         await handler.handleMessage('g1', 'Alice', '@bot what is this', 1000, [
@@ -762,7 +720,7 @@ describe('MessageHandler', () => {
           storage: mockStorage,
           llmClient: mockLLM,
           signalClient: mockSignal,
-          messageContext: makeContext({ attachmentsDir: '/data/attachments' }),
+          appConfig: makeAppConfig({ attachmentsDir: '/data/attachments' }),
         });
 
         await handler.handleMessage('g1', 'Bob', '@bot what was that image', 1000);
@@ -976,17 +934,16 @@ describe('MessageHandler', () => {
           name: 'Pirate',
           description: 'Ye be a pirate captain! Speak in pirate dialect.',
           tags: 'fun,pirate',
-          isDefault: false,
+          isDefault: 0,
           createdAt: 1000,
           updatedAt: 1000,
         });
 
-        const handler = new MessageHandler(['@bot'], {
-          storage: mockStorage,
-          llmClient: mockLLM,
-          signalClient: mockSignal,
-          systemPrompt: 'Default assistant prompt.',
-        });
+        const handler = new MessageHandler(
+          ['@bot'],
+          { storage: mockStorage, llmClient: mockLLM, signalClient: mockSignal },
+          { systemPrompt: 'Default assistant prompt.' },
+        );
 
         await handler.handleMessage('g1', 'Alice', '@bot hello', 1000);
 
@@ -1000,12 +957,11 @@ describe('MessageHandler', () => {
       it('should fall back to system prompt when no active persona', async () => {
         mockStorage.getActivePersonaForGroup = vi.fn().mockReturnValue(null);
 
-        const handler = new MessageHandler(['@bot'], {
-          storage: mockStorage,
-          llmClient: mockLLM,
-          signalClient: mockSignal,
-          systemPrompt: 'Default assistant prompt.',
-        });
+        const handler = new MessageHandler(
+          ['@bot'],
+          { storage: mockStorage, llmClient: mockLLM, signalClient: mockSignal },
+          { systemPrompt: 'Default assistant prompt.' },
+        );
 
         await handler.handleMessage('g1', 'Alice', '@bot hello', 1000);
 


### PR DESCRIPTION
## Summary
- **LLMClient interface** in `types.ts` — `ClaudeCLIClient` implements it, `MessageHandler` depends on the interface
- **Split MessageContext** into `AppConfig` (static config) and `RequestContext` (per-message groupId/sender), with `MessageContext = AppConfig & RequestContext` for backward compat
- **Required core deps** — `MessageHandler` constructor now requires `storage`, `llmClient`, `signalClient` as non-optional, removing runtime null checks and `as` casts
- **Removed inline SignalClient stub** — no more `{ sendTyping: async () => {} } as SignalClient`
- **Extracted `assembleAdditionalContext`** from `processLlmRequest` for dossier/skill/persona loading
- **Extracted `parseClaudeOutput`** as standalone exported function from `ClaudeCLIClient`
- **Lazy `ALLOWED_TOOLS`** via `getAllowedTools()` to avoid module-load-time side effects
- **Prompt constants** extracted to module-level `SOURCE_CODE_INSTRUCTIONS`, `VOICE_MESSAGE_INSTRUCTIONS`, `IMAGE_INSTRUCTIONS`
- **`formatCurrentTimeISO()`** extracted as private method on `ContextBuilder`
- **Shared `formatTimestamp`** utility in `bot/src/utils/dateFormat.ts`, deduplicating between `contextBuilder.ts` and `messageHistory.ts`
- **`estimateTokens()`** used in `contextBuilder.ts` instead of inline `Math.ceil(length/4)`

## Test plan
- [x] All 70 tests in messageHandler.test.ts and contextBuilder.test.ts pass
- [x] parseClaudeOutput tests added to claudeClient.test.ts
- [x] biome check passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)