### PR TITLE
feat: add BOM radar image tool for weather MCP server

### DIFF
--- a/bot/src/mcp/servers/weather.ts
+++ b/bot/src/mcp/servers/weather.ts
@@ -376,7 +376,10 @@ export const weatherServer: McpServerDefinition = {
       }
 
       const range = optionalString(args, 'range', '128km');
-      const suffix = RANGE_MAP[range] ?? '3';
+      const suffix = RANGE_MAP[range];
+      if (!suffix) {
+        return error(`Invalid range "${range}". Valid ranges: ${Object.keys(RANGE_MAP).join(', ')}`);
+      }
 
       return catchErrors(async () => {
         const productId = `IDR${station.code}${suffix}`;

--- a/bot/tests/weatherMcpServer.test.ts
+++ b/bot/tests/weatherMcpServer.test.ts
@@ -295,4 +295,48 @@ describe('Weather MCP Server', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('location');
   });
+
+  it('should fetch radar image with explicit range parameter', async () => {
+    const server = spawnMcpServer();
+    await initializeServer(server);
+
+    const response = await sendAndReceive(
+      server,
+      {
+        jsonrpc: '2.0',
+        id: 16,
+        method: 'tools/call',
+        params: { name: 'get_radar_image', arguments: { location: 'Sydney', range: '256km' } },
+      },
+      30000,
+    );
+
+    const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    // Product ID should use suffix '2' for 256km (IDR712)
+    expect(text).toContain('IDR712');
+    expect(text).toContain('256km');
+
+    // Clean up temp file
+    const match = text.match(/(\/\S+\.gif)/);
+    if (match) fs.unlinkSync(match[1]);
+  }, 30000);
+
+  it('should return error for invalid range parameter', async () => {
+    const server = spawnMcpServer();
+    await initializeServer(server);
+
+    const response = await sendAndReceive(server, {
+      jsonrpc: '2.0',
+      id: 17,
+      method: 'tools/call',
+      params: { name: 'get_radar_image', arguments: { location: 'Sydney', range: '999km' } },
+    });
+
+    const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Invalid range');
+    expect(result.content[0].text).toContain('128km');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `get_radar_image` MCP tool to the weather server that fetches BOM radar GIFs
- Maps ~17 Australian locations (with aliases) to BOM radar station codes
- Downloads pre-composited animated GIF, validates GIF magic bytes, saves to temp file
- Claude chains this with existing `send_image` tool to deliver radar images in chat
- Supports optional range parameter (64km/128km/256km/512km, default 128km)

Closes #5

## Changes
- `bot/src/mcp/servers/weather.ts` — New `get_radar_image` tool with station mapping, range support, content validation, and temp file cleanup
- `bot/tests/weatherMcpServer.test.ts` — 4 new tests (valid location, unknown location, case-insensitive, missing param)

## Test Plan
- [x] All 654 existing tests pass
- [x] New tests cover acceptance criteria:
  - [x] Fetches radar GIF for valid location (Sydney) and verifies GIF magic bytes
  - [x] Returns error with station list for unknown location
  - [x] Case-insensitive location lookup works
  - [x] Missing location parameter returns error
- [x] Lint and format checks pass (biome)
- [ ] Manual test via mock signal server

## Factory Run
Artifacts: `factory/runs/issue-5/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)