### PR TITLE
feat: add GitHub PR tools to MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Image attachments sent in Signal messages are stored as BLOBs in the `attachment
 - `index.ts` — Barrel: ALL_SERVERS array (add new server = add one import here)
 - `reminders.ts` — set/list/cancel reminders (3 tools)
 - `weather.ts` — BOM weather: search, observations, forecast, warnings (4 tools)
-- `github.ts` — Create GitHub issues from feature requests (1 tool)
+- `github.ts` — GitHub integration: feature request issues, PR list/view/diff/comment/review/merge (7 tools)
 - `dossiers.ts` — Person dossier CRUD (3 tools)
 - `sourceCode.ts` — List/read/search source files (3 tools). Paths are relative to `bot/`, not the repo root (e.g., use `src/index.ts` not `bot/src/index.ts`)
 - `messageHistory.ts` — Search and date-range message queries (2 tools)

--- a/bot/src/mcp/servers/github.ts
+++ b/bot/src/mcp/servers/github.ts
@@ -225,7 +225,7 @@ export const githubServer: McpServerDefinition = {
             '--limit',
             String(limit),
             '--json',
-            'number,title,state,author,url,isDraft,createdAt,updatedAt',
+            'number,title,state,author,url,isDraft',
           ],
           { timeout: GH_TIMEOUT },
         );
@@ -259,7 +259,7 @@ export const githubServer: McpServerDefinition = {
 
       return catchErrors(async () => {
         const { stdout } = await execFileAsync('gh', ['api', `repos/${githubRepo}/pulls/${num.value}`], {
-          timeout: 30000,
+          timeout: GH_TIMEOUT,
         });
 
         const pr = JSON.parse(stdout) as {

--- a/bot/tests/githubMcpServer.test.ts
+++ b/bot/tests/githubMcpServer.test.ts
@@ -279,6 +279,21 @@ describe('GitHub MCP Server', () => {
 
   // --- merge_pull_request ---
 
+  it('should return error for merge_pull_request with invalid strategy', async () => {
+    const server = spawnMcpServer({ GITHUB_REPO: 'owner/repo' });
+    await initializeServer(server);
+    const response = await sendAndReceive(server, {
+      jsonrpc: '2.0',
+      id: 18,
+      method: 'tools/call',
+      params: { name: 'merge_pull_request', arguments: { number: 1, strategy: 'fast-forward' } },
+    });
+
+    const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Invalid strategy');
+  });
+
   it('should return error for merge_pull_request when number is missing', async () => {
     const server = spawnMcpServer({ GITHUB_REPO: 'owner/repo' });
     await initializeServer(server);


### PR DESCRIPTION
## Summary
- Add 6 PR tools to existing `github.ts` MCP server: list, view, diff, comment, review, merge
- Uses `gh api` for viewing individual PRs (avoids GraphQL errors), `gh pr` for actions
- Extracted shared constants (`GH_TIMEOUT`, `MERGE_STRATEGIES`, `REVIEW_EVENT_FLAGS`) and `validateRepo()` helper

Closes #35

## Changes
- `bot/src/mcp/servers/github.ts` — 6 new tool definitions + handlers, `validateRepo()` helper, shared constants
- `bot/tests/githubMcpServer.test.ts` — 10 new tests (validation, review body requirement, tool count)

## Test Plan
- [x] All existing tests pass (694/694)
- [x] New tests cover all 6 tool validation paths
- [x] Review body required for COMMENT/REQUEST_CHANGES
- [x] Lint and format checks pass
- [ ] Integration test via mock signal server

## Factory Run
Artifacts: `factory/runs/issue-35/`