### PR TITLE
feat: add notable dates/holidays awareness tool (#52)

### DIFF
--- a/bot/src/mcp/servers/index.ts
+++ b/bot/src/mcp/servers/index.ts
@@ -5,12 +5,12 @@ import { githubServer } from './github';
 import { imagesServer } from './images';
 import { memoryServer } from './memories';
 import { messageHistoryServer } from './messageHistory';
+import { notableDatesServer } from './notableDates';
 import { personaServer } from './personas';
 import { reminderServer } from './reminders';
 import { settingsServer } from './settings';
 import { signalServer } from './signal';
 import { sourceCodeServer } from './sourceCode';
-import { notableDatesServer } from './notableDates';
 import { weatherServer } from './weather';
 
 export const ALL_SERVERS: McpServerDefinition[] = [

--- a/bot/src/mcp/servers/notableDates.ts
+++ b/bot/src/mcp/servers/notableDates.ts
@@ -6,32 +6,90 @@ import { optionalString } from '../validate';
 /** Curated list of notable dates, keyed by MM-DD. Includes Australian fixed-date holidays and major international observances. */
 const NOTABLE_DATES: Record<string, Array<{ name: string; description: string }>> = {
   '01-01': [{ name: "New Year's Day", description: 'The first day of the year in the Gregorian calendar.' }],
-  '01-26': [{ name: 'Australia Day', description: 'Australian national day marking the arrival of the First Fleet in 1788.' }],
-  '01-27': [{ name: 'International Holocaust Remembrance Day', description: 'UN-designated day honouring Holocaust victims.' }],
+  '01-26': [
+    { name: 'Australia Day', description: 'Australian national day marking the arrival of the First Fleet in 1788.' },
+  ],
+  '01-27': [
+    { name: 'International Holocaust Remembrance Day', description: 'UN-designated day honouring Holocaust victims.' },
+  ],
   '02-14': [{ name: "Valentine's Day", description: 'Day celebrating love and affection.' }],
-  '03-08': [{ name: "International Women's Day", description: "Celebrates women's achievements and advocates for gender equality." }],
-  '03-20': [{ name: 'International Day of Happiness', description: "UN-designated day recognising the importance of happiness in people's lives." }],
+  '03-08': [
+    {
+      name: "International Women's Day",
+      description: "Celebrates women's achievements and advocates for gender equality.",
+    },
+  ],
+  '03-20': [
+    {
+      name: 'International Day of Happiness',
+      description: "UN-designated day recognising the importance of happiness in people's lives.",
+    },
+  ],
   '03-21': [{ name: 'Harmony Day', description: 'Australian day celebrating cultural diversity and inclusiveness.' }],
   '03-22': [{ name: 'World Water Day', description: 'UN-designated day highlighting the importance of freshwater.' }],
   '04-07': [{ name: 'World Health Day', description: 'Marks the founding of the WHO and raises health awareness.' }],
   '04-22': [{ name: 'Earth Day', description: 'Annual event demonstrating support for environmental protection.' }],
-  '04-25': [{ name: 'ANZAC Day', description: 'Day of remembrance for Australian and New Zealand forces who served in wars and conflicts.' }],
+  '04-25': [
+    {
+      name: 'ANZAC Day',
+      description: 'Day of remembrance for Australian and New Zealand forces who served in wars and conflicts.',
+    },
+  ],
   '05-01': [{ name: "International Workers' Day", description: 'Celebrates labourers and the working class.' }],
-  '05-26': [{ name: 'National Sorry Day', description: 'Australian day acknowledging the mistreatment of Aboriginal and Torres Strait Islander peoples.' }],
-  '06-03': [{ name: 'Mabo Day', description: 'Commemorates the High Court Mabo decision recognising native title in Australia.' }],
-  '06-05': [{ name: 'World Environment Day', description: 'UN-designated day encouraging awareness and action for environmental protection.' }],
-  '06-20': [{ name: 'World Refugee Day', description: 'UN-designated day honouring refugees and displaced people worldwide.' }],
-  '08-09': [{ name: "International Day of the World's Indigenous Peoples", description: "UN-designated day recognising indigenous peoples' rights and contributions." }],
+  '05-26': [
+    {
+      name: 'National Sorry Day',
+      description: 'Australian day acknowledging the mistreatment of Aboriginal and Torres Strait Islander peoples.',
+    },
+  ],
+  '06-03': [
+    {
+      name: 'Mabo Day',
+      description: 'Commemorates the High Court Mabo decision recognising native title in Australia.',
+    },
+  ],
+  '06-05': [
+    {
+      name: 'World Environment Day',
+      description: 'UN-designated day encouraging awareness and action for environmental protection.',
+    },
+  ],
+  '06-20': [
+    { name: 'World Refugee Day', description: 'UN-designated day honouring refugees and displaced people worldwide.' },
+  ],
+  '08-09': [
+    {
+      name: "International Day of the World's Indigenous Peoples",
+      description: "UN-designated day recognising indigenous peoples' rights and contributions.",
+    },
+  ],
   '08-12': [{ name: 'International Youth Day', description: 'UN-designated day raising awareness of youth issues.' }],
-  '09-21': [{ name: 'International Day of Peace', description: 'UN-designated day devoted to strengthening the ideals of peace.' }],
+  '09-21': [
+    {
+      name: 'International Day of Peace',
+      description: 'UN-designated day devoted to strengthening the ideals of peace.',
+    },
+  ],
   '10-16': [{ name: 'World Food Day', description: 'Marks the founding of the FAO and promotes food security.' }],
   '10-31': [{ name: 'Halloween', description: "Traditional celebration on the eve of All Saints' Day." }],
   '11-11': [{ name: 'Remembrance Day', description: 'Day to remember those who served and died in armed conflicts.' }],
   '12-01': [{ name: 'World AIDS Day', description: 'International day dedicated to raising awareness of HIV/AIDS.' }],
-  '12-10': [{ name: 'Human Rights Day', description: 'Commemorates the adoption of the Universal Declaration of Human Rights.' }],
-  '12-25': [{ name: 'Christmas Day', description: 'Annual festival commemorating the birth of Jesus Christ, widely celebrated as a cultural holiday.' }],
+  '12-10': [
+    {
+      name: 'Human Rights Day',
+      description: 'Commemorates the adoption of the Universal Declaration of Human Rights.',
+    },
+  ],
+  '12-25': [
+    {
+      name: 'Christmas Day',
+      description: 'Annual festival commemorating the birth of Jesus Christ, widely celebrated as a cultural holiday.',
+    },
+  ],
   '12-26': [{ name: 'Boxing Day', description: 'Australian public holiday the day after Christmas.' }],
-  '12-31': [{ name: "New Year's Eve", description: 'The last day of the year, celebrated with gatherings and festivities.' }],
+  '12-31': [
+    { name: "New Year's Eve", description: 'The last day of the year, celebrated with gatherings and festivities.' },
+  ],
 };
 
 function getCuratedDatesForDate(month: number, day: number): Array<{ name: string; description: string }> {
@@ -66,15 +124,13 @@ async function fetchAustralianHolidays(year: number): Promise<NagerHoliday[]> {
   return holidays;
 }
 
-async function getAustralianHolidaysForDate(
-  dateStr: string,
-): Promise<Array<{ name: string; description: string }>> {
+async function getAustralianHolidaysForDate(dateStr: string): Promise<Array<{ name: string; description: string }>> {
   try {
     const year = Number.parseInt(dateStr.slice(0, 4), 10);
     const holidays = await fetchAustralianHolidays(year);
     return holidays
-      .filter((h) => h.date === dateStr)
-      .map((h) => ({
+      .filter(h => h.date === dateStr)
+      .map(h => ({
         name: h.name,
         description: `Australian public holiday${h.global ? ' (national)' : ' (regional)'}. ${h.types.join(', ')}.`,
       }));
@@ -95,8 +151,7 @@ const TOOLS: ToolDefinition[] = [
       properties: {
         date: {
           type: 'string',
-          description:
-            'Date in YYYY-MM-DD format (e.g., "2026-03-08"). Defaults to today if omitted.',
+          description: 'Date in YYYY-MM-DD format (e.g., "2026-03-08"). Defaults to today if omitted.',
         },
       },
     },
@@ -163,7 +218,7 @@ export const notableDatesServer: McpServerDefinition = {
         }
 
         const header = `Notable dates for ${dateStr}:\n`;
-        const lines = allDates.map((d) => `• ${d.name} — ${d.description}`);
+        const lines = allDates.map(d => `• ${d.name} — ${d.description}`);
         return ok(header + lines.join('\n'));
       }, 'Failed to get notable dates');
     },

--- a/bot/tests/notableDatesMcpServer.test.ts
+++ b/bot/tests/notableDatesMcpServer.test.ts
@@ -1,10 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  initializeServer,
-  sendAndReceive,
-  spawnMcpServer as spawnServer,
-} from './helpers/mcpTestHelpers';
+import { initializeServer, sendAndReceive, spawnMcpServer as spawnServer } from './helpers/mcpTestHelpers';
 
 describe('Notable Dates MCP Server', () => {
   let proc: ChildProcess | null = null;


### PR DESCRIPTION
## Summary
- Adds `get_notable_dates` MCP tool that returns Australian public holidays (via Nager.Date API) and international observances (curated in-code map) for any date
- Hybrid data sources: API provides variable-date holidays (Easter, King's Birthday), curated map covers 27 fixed-date entries (IWD, ANZAC Day, Australia Day, etc.)
- Graceful fallback — curated entries always work even if API is down; 5s timeout, in-memory year cache

## Test Plan
- [x] 9 unit tests passing (tool list, IWD, Australia Day, today default, invalid format, impossible date, no observances, extreme year fallback, unknown tool)
- [x] Biome lint + format clean
- [ ] Manual test via mock signal server (`claude: what's special about today?`)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)