### PR TITLE
fix: improve reminder system robustness

### DIFF
--- a/bot/src/reminderScheduler.ts
+++ b/bot/src/reminderScheduler.ts
@@ -44,7 +44,7 @@ export class ReminderScheduler {
     let total = 0;
 
     for (const groupId of groups) {
-      const reminders = store.getDueByGroup(groupId, now, 1);
+      const reminders = store.getDueByGroup(groupId, now, PER_GROUP_LIMIT);
       for (const reminder of reminders) {
         try {
           const claimed = store.markInFlight(reminder.id);
@@ -52,7 +52,7 @@ export class ReminderScheduler {
 
           await executor.execute(reminder);
 
-          const nextDueAt = computeNextDue(reminder.cronExpression, reminder.timezone);
+          const nextDueAt = this.safeNextDue(computeNextDue(reminder.cronExpression, reminder.timezone), now);
           store.markFired(reminder.id, nextDueAt);
           total++;
         } catch (error) {
@@ -67,11 +67,10 @@ export class ReminderScheduler {
 
   private async handleRecurringFailure(reminder: RecurringReminder): Promise<void> {
     const store = this.recurringStore as RecurringReminderStore;
+    const now = Date.now();
 
-    const nextDueAt = computeNextDue(reminder.cronExpression, reminder.timezone);
-    store.advanceNextDue(reminder.id, nextDueAt);
-
-    const failures = store.incrementFailures(reminder.id);
+    const nextDueAt = this.safeNextDue(computeNextDue(reminder.cronExpression, reminder.timezone), now);
+    const failures = store.handleFailure(reminder.id, nextDueAt);
     if (failures >= MAX_CONSECUTIVE_FAILURES) {
       store.cancel(reminder.id, reminder.groupId);
       try {
@@ -124,9 +123,6 @@ export class ReminderScheduler {
       }
     }
 
-    // Claim-then-send: record attempt BEFORE sending
-    this.reminderStore.recordAttempt(reminder.id);
-
     try {
       if (reminder.mode === 'prompt') {
         if (!this.recurringExecutor) {
@@ -143,12 +139,12 @@ export class ReminderScheduler {
         const messageText = this.formatReminderMessage(reminder, staleness);
         await this.signalClient.sendMessage(reminder.groupId, messageText);
       }
-      this.reminderStore.markSent(reminder.id);
+      this.reminderStore.completeReminder(reminder.id);
       return true;
     } catch (error) {
       logger.error(`Failed to ${reminder.mode === 'prompt' ? 'execute' : 'send'} reminder ${reminder.id}:`, error);
-      // Don't mark failed — recordAttempt already incremented retryCount
-      // Will retry on next cycle (with backoff)
+      // Record attempt on failure to enable backoff on next cycle
+      this.reminderStore.recordAttempt(reminder.id);
       return false;
     }
   }
@@ -160,6 +156,14 @@ export class ReminderScheduler {
     } catch {
       logger.error(`Failed to send failure notification for reminder ${reminder.id}`);
     }
+  }
+
+  private safeNextDue(nextDueAt: number, now: number): number {
+    if (nextDueAt <= now) {
+      logger.warn(`computeNextDue returned past timestamp ${nextDueAt}, adding 60s minimum delay`);
+      return now + 60_000;
+    }
+    return nextDueAt;
   }
 
   private formatReminderMessage(reminder: Reminder, stalenessMs: number): string {

--- a/bot/src/storage.ts
+++ b/bot/src/storage.ts
@@ -1,12 +1,12 @@
 import { DatabaseConnection } from './db';
 import { AttachmentStore } from './stores/attachmentStore';
 import { DossierStore } from './stores/dossierStore';
+import { GroupSettingsStore } from './stores/groupSettingsStore';
 import { MemoryStore } from './stores/memoryStore';
 import { MessageStore } from './stores/messageStore';
 import { PersonaStore } from './stores/personaStore';
 import { RecurringReminderStore } from './stores/recurringReminderStore';
 import { ReminderStore } from './stores/reminderStore';
-import { GroupSettingsStore } from './stores/groupSettingsStore';
 import type { Attachment, Dossier, Memory, Message, Persona, Reminder, ReminderMode } from './types';
 
 export class Storage {
@@ -75,20 +75,8 @@ export class Storage {
     return this.reminders.create(groupId, requester, reminderText, dueAt, mode);
   }
 
-  getDueReminders(now?: number, limit = 50): Reminder[] {
-    return this.reminders.getDueReminders(now, limit);
-  }
-
   markReminderSent(id: number): boolean {
     return this.reminders.markSent(id);
-  }
-
-  markReminderFailed(id: number): boolean {
-    return this.reminders.markFailedLegacy(id);
-  }
-
-  incrementReminderRetry(id: number): void {
-    this.reminders.incrementRetry(id);
   }
 
   cancelReminder(id: number, groupId: string): boolean {

--- a/bot/src/stores/recurringReminderStore.ts
+++ b/bot/src/stores/recurringReminderStore.ts
@@ -31,6 +31,8 @@ export class RecurringReminderStore {
     incrementFailures: Database.Statement;
     advanceNextDue: Database.Statement;
     getById: Database.Statement;
+    listAllNoFilter: Database.Statement;
+    listAllByGroup: Database.Statement;
   };
 
   constructor(conn: DatabaseConnection) {
@@ -84,6 +86,12 @@ export class RecurringReminderStore {
       getById: conn.db.prepare(`
         SELECT * FROM recurring_reminders WHERE id = ?
       `),
+      listAllNoFilter: conn.db.prepare(
+        `SELECT * FROM recurring_reminders WHERE status = '${STATUS.active}' ORDER BY nextDueAt ASC LIMIT ? OFFSET ?`,
+      ),
+      listAllByGroup: conn.db.prepare(
+        `SELECT * FROM recurring_reminders WHERE status = '${STATUS.active}' AND groupId = ? ORDER BY nextDueAt ASC LIMIT ? OFFSET ?`,
+      ),
     };
   }
 
@@ -186,29 +194,33 @@ export class RecurringReminderStore {
     return this.conn.runOp('list all recurring reminders', () => {
       const limit = Math.min(filters?.limit ?? 50, 200);
       const offset = filters?.offset ?? 0;
-      const conditions: string[] = ['status = ?'];
-      const params: unknown[] = ['active'];
 
+      let rows: Array<RecurringReminderRow>;
       if (filters?.groupId) {
-        conditions.push('groupId = ?');
-        params.push(filters.groupId);
+        rows = this.stmts.listAllByGroup.all(filters.groupId, limit, offset) as Array<RecurringReminderRow>;
+      } else {
+        rows = this.stmts.listAllNoFilter.all(limit, offset) as Array<RecurringReminderRow>;
       }
-
-      const where = `WHERE ${conditions.join(' AND ')}`;
-      const sql = `SELECT * FROM recurring_reminders ${where} ORDER BY nextDueAt ASC LIMIT ? OFFSET ?`;
-      params.push(limit, offset);
-
-      const rows = this.conn.db.prepare(sql).all(...params) as Array<RecurringReminderRow>;
       return rows.map(mapRow);
     });
   }
 
   resetFailures(id: number): boolean {
     return this.conn.runOp('reset recurring reminder failures', () => {
-      const result = this.conn.db.prepare(
-        'UPDATE recurring_reminders SET consecutiveFailures = 0 WHERE id = ?'
-      ).run(id);
+      const result = this.conn.db
+        .prepare('UPDATE recurring_reminders SET consecutiveFailures = 0 WHERE id = ?')
+        .run(id);
       return result.changes > 0;
+    });
+  }
+
+  handleFailure(id: number, nextDueAt: number): number {
+    return this.conn.transaction(() => {
+      const now = Date.now();
+      this.stmts.advanceNextDue.run(nextDueAt, now, id);
+      this.stmts.incrementFailures.run(now, id);
+      const row = this.stmts.getById.get(id) as RecurringReminderRow | undefined;
+      return row?.consecutiveFailures ?? 0;
     });
   }
 

--- a/bot/src/stores/reminderStore.ts
+++ b/bot/src/stores/reminderStore.ts
@@ -23,12 +23,15 @@ export class ReminderStore {
     getDueByGroup: Database.Statement;
     getGroupsWithDueReminders: Database.Statement;
     markSent: Database.Statement;
+    completeReminder: Database.Statement;
     markFailed: Database.Statement;
     recordAttempt: Database.Statement;
     cancel: Database.Statement;
     listPending: Database.Statement;
-    selectDueReminders: Database.Statement;
-    incrementRetry: Database.Statement;
+    listAllNoFilter: Database.Statement;
+    listAllByGroup: Database.Statement;
+    listAllByStatus: Database.Statement;
+    listAllByGroupAndStatus: Database.Statement;
   };
 
   constructor(conn: DatabaseConnection) {
@@ -51,6 +54,10 @@ export class ReminderStore {
       markSent: conn.db.prepare(`
         UPDATE reminders SET status = '${STATUS.sent}', sentAt = ? WHERE id = ? AND status = '${STATUS.pending}'
       `),
+      completeReminder: conn.db.prepare(`
+        UPDATE reminders SET status = '${STATUS.sent}', sentAt = ?, lastAttemptAt = ?, retryCount = retryCount + 1
+        WHERE id = ? AND status = '${STATUS.pending}'
+      `),
       markFailed: conn.db.prepare(`
         UPDATE reminders SET status = '${STATUS.failed}', failureReason = ? WHERE id = ? AND status = '${STATUS.pending}'
       `),
@@ -65,17 +72,12 @@ export class ReminderStore {
         WHERE groupId = ? AND status = '${STATUS.pending}'
         ORDER BY dueAt ASC
       `),
-      // Legacy compat: due reminders without group filter
-      selectDueReminders: conn.db.prepare(`
-        SELECT * FROM reminders
-        WHERE status = '${STATUS.pending}' AND dueAt <= ?
-        ORDER BY dueAt ASC
-        LIMIT ?
-      `),
-      // Legacy compat: increment retry without setting lastAttemptAt
-      incrementRetry: conn.db.prepare(`
-        UPDATE reminders SET retryCount = retryCount + 1 WHERE id = ?
-      `),
+      listAllNoFilter: conn.db.prepare('SELECT * FROM reminders ORDER BY dueAt DESC LIMIT ? OFFSET ?'),
+      listAllByGroup: conn.db.prepare('SELECT * FROM reminders WHERE groupId = ? ORDER BY dueAt DESC LIMIT ? OFFSET ?'),
+      listAllByStatus: conn.db.prepare('SELECT * FROM reminders WHERE status = ? ORDER BY dueAt DESC LIMIT ? OFFSET ?'),
+      listAllByGroupAndStatus: conn.db.prepare(
+        'SELECT * FROM reminders WHERE groupId = ? AND status = ? ORDER BY dueAt DESC LIMIT ? OFFSET ?',
+      ),
     };
   }
 
@@ -123,6 +125,14 @@ export class ReminderStore {
     });
   }
 
+  completeReminder(id: number): boolean {
+    return this.conn.runOp('complete reminder', () => {
+      const now = Date.now();
+      const result = this.stmts.completeReminder.run(now, now, id);
+      return result.changes > 0;
+    });
+  }
+
   markFailed(id: number, reason: string): boolean {
     return this.conn.runOp('mark reminder failed', () => {
       const result = this.stmts.markFailed.run(reason, id);
@@ -157,52 +167,27 @@ export class ReminderStore {
     }
   }
 
-  // Legacy compatibility methods (used by existing Storage facade)
-  getDueReminders(now?: number, limit = 50): Reminder[] {
-    return this.conn.runOp('get due reminders', () => {
-      const rows = this.stmts.selectDueReminders.all(now ?? Date.now(), limit) as Array<ReminderRow>;
-      return rows.map(mapReminderRow);
-    });
-  }
-
-  /**
-   * Legacy: mark failed without reason (for backward compat with old Storage API)
-   */
-  markFailedLegacy(id: number): boolean {
-    return this.markFailed(id, '');
-  }
-
   listAll(filters?: { groupId?: string; status?: string; limit?: number; offset?: number }): Reminder[] {
     return this.conn.runOp('list all reminders', () => {
       const limit = Math.min(filters?.limit ?? 50, 200);
       const offset = filters?.offset ?? 0;
-      const conditions: string[] = [];
-      const params: unknown[] = [];
 
-      if (filters?.groupId) {
-        conditions.push('groupId = ?');
-        params.push(filters.groupId);
+      let rows: Array<ReminderRow>;
+      if (filters?.groupId && filters?.status) {
+        rows = this.stmts.listAllByGroupAndStatus.all(
+          filters.groupId,
+          filters.status,
+          limit,
+          offset,
+        ) as Array<ReminderRow>;
+      } else if (filters?.groupId) {
+        rows = this.stmts.listAllByGroup.all(filters.groupId, limit, offset) as Array<ReminderRow>;
+      } else if (filters?.status) {
+        rows = this.stmts.listAllByStatus.all(filters.status, limit, offset) as Array<ReminderRow>;
+      } else {
+        rows = this.stmts.listAllNoFilter.all(limit, offset) as Array<ReminderRow>;
       }
-      if (filters?.status) {
-        conditions.push('status = ?');
-        params.push(filters.status);
-      }
-
-      const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-      const sql = `SELECT * FROM reminders ${where} ORDER BY dueAt DESC LIMIT ? OFFSET ?`;
-      params.push(limit, offset);
-
-      const rows = this.conn.db.prepare(sql).all(...params) as Array<ReminderRow>;
       return rows.map(mapReminderRow);
-    });
-  }
-
-  /**
-   * Legacy: increment retry without setting lastAttemptAt
-   */
-  incrementRetry(id: number): void {
-    this.conn.runOp('increment reminder retry', () => {
-      this.stmts.incrementRetry.run(id);
     });
   }
 }

--- a/bot/tests/reminderScheduler.recurring.test.ts
+++ b/bot/tests/reminderScheduler.recurring.test.ts
@@ -63,6 +63,7 @@ function createMockStore() {
     getDueByGroup: vi.fn().mockReturnValue([]),
     recordAttempt: vi.fn(),
     markSent: vi.fn().mockReturnValue(true),
+    completeReminder: vi.fn().mockReturnValue(true),
     markFailed: vi.fn().mockReturnValue(true),
     create: vi.fn(),
     cancel: vi.fn(),
@@ -80,6 +81,7 @@ function createMockRecurringStore() {
     advanceNextDue: vi.fn(),
     cancel: vi.fn().mockReturnValue(true),
     incrementFailures: vi.fn().mockReturnValue(1),
+    handleFailure: vi.fn().mockReturnValue(1),
     listActive: vi.fn().mockReturnValue([]),
     create: vi.fn(),
   };
@@ -135,7 +137,7 @@ describe('ReminderScheduler — recurring reminders', () => {
 
     // One-shot sent + recurring processed
     expect(count).toBe(2);
-    expect(mockStore.markSent).toHaveBeenCalledWith(1);
+    expect(mockStore.completeReminder).toHaveBeenCalledWith(1);
     expect(mockRecurringExecutor.execute).toHaveBeenCalledWith(recurring);
     expect(mockRecurringStore.markFired).toHaveBeenCalledWith(100, 9999999999999);
   });
@@ -153,20 +155,18 @@ describe('ReminderScheduler — recurring reminders', () => {
     expect(mockRecurringStore.markFired).not.toHaveBeenCalled();
   });
 
-  it('clears in-flight and advances nextDueAt on executor failure', async () => {
+  it('calls handleFailure on executor failure', async () => {
     const { computeNextDue } = await import('../src/utils/cron');
     const recurring = makeRecurringReminder({ id: 100 });
     mockRecurringStore.getGroupsWithDue.mockReturnValue(['group1']);
     mockRecurringStore.getDueByGroup.mockReturnValue([recurring]);
     mockRecurringExecutor.execute.mockRejectedValue(new Error('Claude timeout'));
-    mockRecurringStore.incrementFailures.mockReturnValue(1);
 
     const count = await scheduler.processDueReminders();
 
     expect(count).toBe(0);
     expect(computeNextDue).toHaveBeenCalledWith(recurring.cronExpression, recurring.timezone);
-    expect(mockRecurringStore.advanceNextDue).toHaveBeenCalledWith(100, 9999999999999);
-    expect(mockRecurringStore.incrementFailures).toHaveBeenCalledWith(100);
+    expect(mockRecurringStore.handleFailure).toHaveBeenCalledWith(100, 9999999999999);
   });
 
   it('works without recurring dependencies (backward compat)', async () => {
@@ -186,14 +186,14 @@ describe('ReminderScheduler — recurring reminders', () => {
   it('auto-cancels after 5 consecutive failures', async () => {
     const recurring = makeRecurringReminder({
       id: 100,
-      consecutiveFailures: 4, // will become 5 after increment
+      consecutiveFailures: 4, // will become 5 after handleFailure
       promptText: 'Daily weather report',
       requester: '+61400111222',
     });
     mockRecurringStore.getGroupsWithDue.mockReturnValue(['group1']);
     mockRecurringStore.getDueByGroup.mockReturnValue([recurring]);
     mockRecurringExecutor.execute.mockRejectedValue(new Error('fail'));
-    mockRecurringStore.incrementFailures.mockReturnValue(5);
+    mockRecurringStore.handleFailure.mockReturnValue(5);
 
     const count = await scheduler.processDueReminders();
 
@@ -204,5 +204,67 @@ describe('ReminderScheduler — recurring reminders', () => {
       expect.stringContaining('Daily weather report'),
     );
     expect(mockSignalClient.sendMessage).toHaveBeenCalledWith('group1', expect.stringContaining('auto-cancelled'));
+  });
+
+  it('should process multiple due recurring reminders per group', async () => {
+    const reminders = [
+      makeRecurringReminder({ id: 100, promptText: 'Task 1' }),
+      makeRecurringReminder({ id: 101, promptText: 'Task 2' }),
+      makeRecurringReminder({ id: 102, promptText: 'Task 3' }),
+    ];
+    mockRecurringStore.getGroupsWithDue.mockReturnValue(['group1']);
+    mockRecurringStore.getDueByGroup.mockReturnValue(reminders);
+
+    const count = await scheduler.processDueReminders();
+
+    expect(count).toBe(3);
+    expect(mockRecurringExecutor.execute).toHaveBeenCalledTimes(3);
+    expect(mockRecurringStore.markFired).toHaveBeenCalledTimes(3);
+  });
+
+  it('should use minimum delay when computeNextDue returns past timestamp', async () => {
+    const { computeNextDue } = await import('../src/utils/cron');
+    const now = Date.now();
+    (computeNextDue as ReturnType<typeof vi.fn>).mockReturnValue(now - 1000);
+
+    const recurring = makeRecurringReminder({ id: 100 });
+    mockRecurringStore.getGroupsWithDue.mockReturnValue(['group1']);
+    mockRecurringStore.getDueByGroup.mockReturnValue([recurring]);
+
+    await scheduler.processDueReminders();
+
+    // markFired should be called with a future timestamp (now + 60s), not the past value
+    const calledWith = mockRecurringStore.markFired.mock.calls[0][1];
+    expect(calledWith).toBeGreaterThan(now);
+  });
+
+  it('should pass through future timestamps from computeNextDue unchanged', async () => {
+    const { computeNextDue } = await import('../src/utils/cron');
+    const farFuture = Date.now() + 86400000; // +24h
+    (computeNextDue as ReturnType<typeof vi.fn>).mockReturnValue(farFuture);
+
+    const recurring = makeRecurringReminder({ id: 100 });
+    mockRecurringStore.getGroupsWithDue.mockReturnValue(['group1']);
+    mockRecurringStore.getDueByGroup.mockReturnValue([recurring]);
+
+    await scheduler.processDueReminders();
+
+    expect(mockRecurringStore.markFired).toHaveBeenCalledWith(100, farFuture);
+  });
+
+  it('should use minimum delay for past timestamps on failure path too', async () => {
+    const { computeNextDue } = await import('../src/utils/cron');
+    const now = Date.now();
+    (computeNextDue as ReturnType<typeof vi.fn>).mockReturnValue(now - 5000);
+
+    const recurring = makeRecurringReminder({ id: 100 });
+    mockRecurringStore.getGroupsWithDue.mockReturnValue(['group1']);
+    mockRecurringStore.getDueByGroup.mockReturnValue([recurring]);
+    mockRecurringExecutor.execute.mockRejectedValue(new Error('fail'));
+
+    await scheduler.processDueReminders();
+
+    const calledWith = mockRecurringStore.handleFailure.mock.calls[0][1];
+    expect(calledWith).toBeGreaterThan(now);
   });
 });

--- a/bot/tests/reminderScheduler.test.ts
+++ b/bot/tests/reminderScheduler.test.ts
@@ -40,6 +40,7 @@ function createMockStore() {
     getDueByGroup: vi.fn().mockReturnValue([]),
     recordAttempt: vi.fn(),
     markSent: vi.fn().mockReturnValue(true),
+    completeReminder: vi.fn().mockReturnValue(true),
     markFailed: vi.fn().mockReturnValue(true),
     create: vi.fn(),
     cancel: vi.fn(),
@@ -113,20 +114,22 @@ describe('ReminderScheduler', () => {
       const count = await scheduler.processDueReminders();
 
       expect(count).toBe(1);
-      // Both groups were still processed
-      expect(mockStore.recordAttempt).toHaveBeenCalledTimes(2);
+      // Both groups were still processed: 1 failed (recordAttempt) + 1 succeeded (completeReminder)
+      expect(mockStore.recordAttempt).toHaveBeenCalledTimes(1);
+      expect(mockStore.completeReminder).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('claim-then-send pattern', () => {
-    it('should call recordAttempt before sendMessage', async () => {
+  describe('send-then-complete pattern', () => {
+    it('should call completeReminder after successful sendMessage', async () => {
       const reminder = makeReminder();
       mockStore.getGroupsWithDueReminders.mockReturnValue(['group1']);
       mockStore.getDueByGroup.mockReturnValue([reminder]);
 
       const callOrder: string[] = [];
-      mockStore.recordAttempt.mockImplementation(() => {
-        callOrder.push('recordAttempt');
+      mockStore.completeReminder.mockImplementation(() => {
+        callOrder.push('completeReminder');
+        return true;
       });
       mockSignalClient.sendMessage.mockImplementation(async () => {
         callOrder.push('sendMessage');
@@ -134,31 +137,31 @@ describe('ReminderScheduler', () => {
 
       await scheduler.processDueReminders();
 
-      expect(callOrder).toEqual(['recordAttempt', 'sendMessage']);
+      expect(callOrder).toEqual(['sendMessage', 'completeReminder']);
     });
 
-    it('should call markSent on successful send', async () => {
+    it('should call completeReminder on successful send', async () => {
       const reminder = makeReminder({ id: 42 });
       mockStore.getGroupsWithDueReminders.mockReturnValue(['group1']);
       mockStore.getDueByGroup.mockReturnValue([reminder]);
 
       await scheduler.processDueReminders();
 
-      expect(mockStore.markSent).toHaveBeenCalledWith(42);
+      expect(mockStore.completeReminder).toHaveBeenCalledWith(42);
     });
 
-    it('should not error when markSent returns false (already handled)', async () => {
+    it('should not error when completeReminder returns false (already handled)', async () => {
       const reminder = makeReminder({ id: 42 });
       mockStore.getGroupsWithDueReminders.mockReturnValue(['group1']);
       mockStore.getDueByGroup.mockReturnValue([reminder]);
-      mockStore.markSent.mockReturnValue(false);
+      mockStore.completeReminder.mockReturnValue(false);
 
       const count = await scheduler.processDueReminders();
 
       expect(count).toBe(1); // Still counts as sent from the scheduler's perspective
     });
 
-    it('should not call markFailed on send failure', async () => {
+    it('should call recordAttempt on send failure (not completeReminder)', async () => {
       const reminder = makeReminder();
       mockStore.getGroupsWithDueReminders.mockReturnValue(['group1']);
       mockStore.getDueByGroup.mockReturnValue([reminder]);
@@ -168,6 +171,7 @@ describe('ReminderScheduler', () => {
 
       expect(mockStore.markFailed).not.toHaveBeenCalled();
       expect(mockStore.recordAttempt).toHaveBeenCalledWith(1);
+      expect(mockStore.completeReminder).not.toHaveBeenCalled();
     });
   });
 
@@ -229,7 +233,7 @@ describe('ReminderScheduler', () => {
       const count = await scheduler.processDueReminders();
 
       expect(count).toBe(1);
-      expect(mockStore.recordAttempt).toHaveBeenCalled();
+      expect(mockStore.completeReminder).toHaveBeenCalled();
     });
 
     it('should always process first attempt (lastAttemptAt is null)', async () => {
@@ -243,7 +247,7 @@ describe('ReminderScheduler', () => {
       const count = await scheduler.processDueReminders();
 
       expect(count).toBe(1);
-      expect(mockStore.recordAttempt).toHaveBeenCalled();
+      expect(mockStore.completeReminder).toHaveBeenCalled();
     });
   });
 
@@ -437,7 +441,7 @@ describe('ReminderScheduler', () => {
       expect(mockSignalClient.sendMessage).not.toHaveBeenCalled();
     });
 
-    it('marks prompt mode reminder as sent after successful execution', async () => {
+    it('marks prompt mode reminder as completed after successful execution', async () => {
       const reminder = makeReminder({ mode: 'prompt' });
       mockStore.getGroupsWithDueReminders.mockReturnValue(['group1']);
       mockStore.getDueByGroup.mockReturnValue([reminder]);
@@ -448,7 +452,7 @@ describe('ReminderScheduler', () => {
         mockExecutor as any,
       );
       await promptScheduler.processDueReminders();
-      expect(mockStore.markSent).toHaveBeenCalledWith(reminder.id);
+      expect(mockStore.completeReminder).toHaveBeenCalledWith(reminder.id);
     });
 
     it('does not crash when executor throws for prompt mode (retry on next cycle)', async () => {
@@ -491,8 +495,9 @@ describe('ReminderScheduler', () => {
       const count = await scheduler.processDueReminders();
 
       expect(count).toBe(1);
-      expect(mockStore.recordAttempt).toHaveBeenCalledTimes(2);
-      expect(mockStore.markSent).toHaveBeenCalledWith(2);
+      // First reminder failed (recordAttempt), second succeeded (completeReminder)
+      expect(mockStore.recordAttempt).toHaveBeenCalledTimes(1);
+      expect(mockStore.completeReminder).toHaveBeenCalledWith(2);
     });
 
     it('should not propagate Signal API error on notification', async () => {

--- a/bot/tests/storage.reminders.test.ts
+++ b/bot/tests/storage.reminders.test.ts
@@ -44,78 +44,6 @@ describe('Storage - Reminders', () => {
     });
   });
 
-  describe('getDueReminders', () => {
-    it('should return empty array when no reminders exist', () => {
-      const storage = createStorage();
-      const reminders = storage.getDueReminders(Date.now());
-      expect(reminders).toEqual([]);
-    });
-
-    it('should return only pending reminders where dueAt <= now', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      storage.createReminder('group1', 'Alice', 'Due reminder', now - 60000);
-      storage.createReminder('group1', 'Alice', 'Future reminder', now + 60000);
-      vi.restoreAllMocks();
-
-      const reminders = storage.getDueReminders(now);
-      expect(reminders).toHaveLength(1);
-      expect(reminders[0].reminderText).toBe('Due reminder');
-      expect(reminders[0].status).toBe('pending');
-    });
-
-    it('should not return sent reminders', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
-      vi.restoreAllMocks();
-
-      storage.markReminderSent(id);
-      const reminders = storage.getDueReminders(now);
-      expect(reminders).toHaveLength(0);
-    });
-
-    it('should not return failed reminders', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
-      vi.restoreAllMocks();
-
-      storage.markReminderFailed(id);
-      const reminders = storage.getDueReminders(now);
-      expect(reminders).toHaveLength(0);
-    });
-
-    it('should respect the limit parameter', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      for (let i = 0; i < 5; i++) {
-        storage.createReminder('group1', 'Alice', `Reminder ${i}`, now - 60000 + i);
-      }
-      vi.restoreAllMocks();
-
-      const reminders = storage.getDueReminders(now, 3);
-      expect(reminders).toHaveLength(3);
-    });
-
-    it('should return results ordered by dueAt ASC', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 200000);
-      storage.createReminder('group1', 'Alice', 'Later', now - 30000);
-      storage.createReminder('group1', 'Alice', 'Earlier', now - 60000);
-      vi.restoreAllMocks();
-
-      const reminders = storage.getDueReminders(now);
-      expect(reminders[0].reminderText).toBe('Earlier');
-      expect(reminders[1].reminderText).toBe('Later');
-    });
-  });
-
   describe('markReminderSent', () => {
     it('should mark a pending reminder as sent', () => {
       const storage = createStorage();
@@ -127,7 +55,7 @@ describe('Storage - Reminders', () => {
       const result = storage.markReminderSent(id);
       expect(result).toBe(true);
 
-      const reminders = storage.getDueReminders(now);
+      const reminders = storage.reminders.getDueByGroup('group1', now, 50);
       expect(reminders).toHaveLength(0);
     });
 
@@ -147,47 +75,6 @@ describe('Storage - Reminders', () => {
       createStorage();
       const result = ts.storage.markReminderSent(999);
       expect(result).toBe(false);
-    });
-  });
-
-  describe('markReminderFailed', () => {
-    it('should mark a pending reminder as failed', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
-      vi.restoreAllMocks();
-
-      const result = storage.markReminderFailed(id);
-      expect(result).toBe(true);
-    });
-
-    it('should return false for non-pending reminders', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
-      vi.restoreAllMocks();
-
-      storage.markReminderSent(id);
-      const result = storage.markReminderFailed(id);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('incrementReminderRetry', () => {
-    it('should increment the retry count', () => {
-      const storage = createStorage();
-      const now = Date.now();
-      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
-      const id = storage.createReminder('group1', 'Alice', 'Test', now - 60000);
-      vi.restoreAllMocks();
-
-      storage.incrementReminderRetry(id);
-      storage.incrementReminderRetry(id);
-
-      const reminders = storage.getDueReminders(now);
-      expect(reminders[0].retryCount).toBe(2);
     });
   });
 
@@ -277,12 +164,6 @@ describe('Storage - Reminders', () => {
       const storage = createStorage();
       storage.close();
       expect(() => storage.createReminder('g1', 'Alice', 'Test', Date.now() + 60000)).toThrow('Database is closed');
-    });
-
-    it('should throw on getDueReminders after close', () => {
-      const storage = createStorage();
-      storage.close();
-      expect(() => storage.getDueReminders()).toThrow('Database is closed');
     });
 
     it('should throw on listReminders after close', () => {

--- a/bot/tests/stores/recurringReminderStore.test.ts
+++ b/bot/tests/stores/recurringReminderStore.test.ts
@@ -322,6 +322,34 @@ describe('RecurringReminderStore', () => {
     });
   });
 
+  describe('handleFailure', () => {
+    it('should atomically advance nextDueAt, clear lastInFlightAt, and increment failures', () => {
+      setup();
+      const id = store.create('group1', 'Alice', 'Task', '0 9 * * *', 'UTC', NOW - 1000);
+      store.markInFlight(id);
+
+      const failures = store.handleFailure(id, NEXT_DUE);
+      expect(failures).toBe(1);
+
+      const active = store.listActive('group1');
+      expect(active).toHaveLength(1);
+      expect(active[0].nextDueAt).toBe(NEXT_DUE);
+      expect(active[0].lastInFlightAt).toBeNull();
+      expect(active[0].consecutiveFailures).toBe(1);
+    });
+
+    it('should return incrementing failure count on repeated calls', () => {
+      setup();
+      const id = store.create('group1', 'Alice', 'Task', '0 9 * * *', 'UTC', NOW - 1000);
+
+      const count1 = store.handleFailure(id, NEXT_DUE);
+      expect(count1).toBe(1);
+
+      const count2 = store.handleFailure(id, NEXT_DUE + 3600000);
+      expect(count2).toBe(2);
+    });
+  });
+
   describe('incrementFailures', () => {
     it('should increment count and return new value', () => {
       setup();

--- a/bot/tests/stores/reminderStore.test.ts
+++ b/bot/tests/stores/reminderStore.test.ts
@@ -227,6 +227,48 @@ describe('ReminderStore', () => {
     });
   });
 
+  describe('completeReminder', () => {
+    it('should transition pending to sent, set sentAt + lastAttemptAt, and increment retryCount', () => {
+      setup();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = store.create('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      const result = store.completeReminder(id);
+      expect(result).toBe(true);
+
+      // Should no longer appear in due reminders (status changed to sent)
+      const due = store.getDueByGroup('group1', now, 50);
+      expect(due).toHaveLength(0);
+
+      // Check the fields via listAll
+      const all = store.listAll({ groupId: 'group1', status: 'sent' });
+      expect(all).toHaveLength(1);
+      expect(all[0].sentAt).toBeGreaterThan(0);
+      expect(all[0].lastAttemptAt).toBeGreaterThan(0);
+      expect(all[0].retryCount).toBe(1);
+    });
+
+    it('should return false for already-sent reminder (idempotent)', () => {
+      setup();
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now - 120000);
+      const id = store.create('group1', 'Alice', 'Test', now - 60000);
+      vi.restoreAllMocks();
+
+      store.completeReminder(id);
+      const result = store.completeReminder(id);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent ID', () => {
+      setup();
+      const result = store.completeReminder(999);
+      expect(result).toBe(false);
+    });
+  });
+
   describe('recordAttempt', () => {
     it('should increment retryCount and set lastAttemptAt', () => {
       setup();


### PR DESCRIPTION
## Summary
- **Atomic state transitions**: New `completeReminder()` store method replaces the split `recordAttempt` → `markSent` pattern, preventing inflated retry counts on successful sends
- **Atomic failure handling**: New `handleFailure()` transaction on `RecurringReminderStore` wraps `advanceNextDue` + `incrementFailures` atomically
- **Hardened SQL**: Replaced dynamic SQL string concatenation in `listAll` with predefined prepared statements (4 for reminders, 2 for recurring)
- **Faster catch-up**: Increased recurring reminder per-group limit from 1 to 20, allowing faster recovery after downtime
- **Past-timestamp guard**: `safeNextDue()` helper prevents tight loops if `computeNextDue` returns a past timestamp (adds 60s minimum delay)
- **Dead code cleanup**: Removed unused legacy methods (`getDueReminders`, `markFailedLegacy`, `incrementRetry`) and their facade wrappers

## Test plan
- [x] All 897 tests pass (57 test files)
- [x] Biome lint + format clean on all 9 modified files
- [x] New tests: `completeReminder` (3 tests), `handleFailure` (2 tests), multi-reminder-per-group (1 test), safeNextDue guard (3 tests)
- [x] Updated scheduler tests reflect new send-then-complete pattern
- [ ] Manual: start mock bot, set a one-shot reminder, verify delivery
- [ ] Manual: set a recurring reminder, verify it fires on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)