### PR TITLE
feat: dashboard join-group via invite link

### DIFF
--- a/bot/src/signalClient.ts
+++ b/bot/src/signalClient.ts
@@ -79,6 +79,10 @@ export class SignalClient {
     await this.rpc<void>('quitGroup', { groupId });
   }
 
+  async joinGroup(uri: string): Promise<void> {
+    await this.rpc<void>('joinGroup', { uri });
+  }
+
   async waitForReady(maxRetries: number = 10, baseDelay: number = 2000): Promise<void> {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {

--- a/bot/tests/signalClient.test.ts
+++ b/bot/tests/signalClient.test.ts
@@ -662,6 +662,42 @@ describe('SignalClient', () => {
     });
   });
 
+  describe('joinGroup', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('calls joinGroup RPC method with uri and account params', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: '1', result: {} }),
+      });
+      const client = new SignalClient('http://localhost:8080', '+61400000000');
+      await expect(client.joinGroup('https://signal.group/#abc123')).resolves.not.toThrow();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.method).toBe('joinGroup');
+      expect(body.params.uri).toBe('https://signal.group/#abc123');
+      expect(body.params.account).toBe('+61400000000');
+    });
+
+    it('throws on RPC error', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: '1', error: { message: 'Invalid group link' } }),
+      });
+      const client = new SignalClient('http://localhost:8080', '+61400000000');
+      await expect(client.joinGroup('https://signal.group/#bad')).rejects.toThrow('Invalid group link');
+    });
+  });
+
   describe('waitForReady', () => {
     let fetchMock: ReturnType<typeof vi.fn>;
 

--- a/dashboard/client/src/hooks/useApi.ts
+++ b/dashboard/client/src/hooks/useApi.ts
@@ -21,7 +21,7 @@ export function useApi<T>(url: string, deps: unknown[] = []) {
 
   useEffect(() => { refetch() }, [refetch, ...deps])
 
-  return { data, loading, error, refetch }
+  return { data, loading, error, refetch, setData }
 }
 
 export async function apiCall(method: string, url: string, body?: unknown): Promise<unknown> {

--- a/dashboard/client/src/pages/Groups.tsx
+++ b/dashboard/client/src/pages/Groups.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useApi } from '../hooks/useApi'
+import { useApi, apiCall } from '../hooks/useApi'
 import DataTable from '../components/DataTable'
 
 interface Group {
@@ -30,12 +31,59 @@ const columns = [
 ]
 
 export default function Groups() {
-  const { data: groups, loading } = useApi<Group[]>('/api/groups')
+  const { data: groups, loading, setData: setGroups, refetch } = useApi<Group[]>('/api/groups')
   const navigate = useNavigate()
+  const [uri, setUri] = useState('')
+  const [joining, setJoining] = useState(false)
+  const [joinError, setJoinError] = useState<string | null>(null)
+  const [joinSuccess, setJoinSuccess] = useState<string | null>(null)
+
+  async function handleJoin(e: React.FormEvent) {
+    e.preventDefault()
+    if (!uri.trim() || joining) return
+    setJoining(true)
+    setJoinError(null)
+    setJoinSuccess(null)
+    try {
+      const result = await apiCall('POST', '/api/groups/join', { uri: uri.trim() }) as
+        | { groups: Group[] }
+        | { message: string }
+      if ('groups' in result) {
+        setGroups(result.groups)
+      } else {
+        // 202 admin approval — show message
+        setJoinSuccess(result.message)
+      }
+      setUri('')
+    } catch (err) {
+      setJoinError((err as Error).message)
+    } finally {
+      setJoining(false)
+    }
+  }
 
   return (
     <div>
       <h1>Groups</h1>
+      <form onSubmit={handleJoin} style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
+        <input
+          type="text"
+          value={uri}
+          onChange={(e) => setUri(e.target.value)}
+          placeholder="Paste Signal group invite link..."
+          disabled={joining}
+          style={{ flex: 1, padding: '8px' }}
+        />
+        <button type="submit" disabled={joining || !uri.trim()}>
+          {joining ? 'Joining...' : 'Join'}
+        </button>
+      </form>
+      {joinError && (
+        <div style={{ color: '#e74c3c', marginBottom: '12px' }}>{joinError}</div>
+      )}
+      {joinSuccess && (
+        <div style={{ color: '#f39c12', marginBottom: '12px' }}>{joinSuccess}</div>
+      )}
       <DataTable<Group>
         columns={columns}
         data={groups ?? []}

--- a/dashboard/client/src/pages/Groups.tsx
+++ b/dashboard/client/src/pages/Groups.tsx
@@ -51,7 +51,6 @@ export default function Groups() {
       if ('groups' in result) {
         setGroups(result.groups)
       } else {
-        // 202 admin approval — show message
         setJoinSuccess(result.message)
       }
       setUri('')

--- a/dashboard/client/src/pages/Groups.tsx
+++ b/dashboard/client/src/pages/Groups.tsx
@@ -31,7 +31,7 @@ const columns = [
 ]
 
 export default function Groups() {
-  const { data: groups, loading, setData: setGroups, refetch } = useApi<Group[]>('/api/groups')
+  const { data: groups, loading, setData: setGroups } = useApi<Group[]>('/api/groups')
   const navigate = useNavigate()
   const [uri, setUri] = useState('')
   const [joining, setJoining] = useState(false)

--- a/dashboard/src/routes/groups.ts
+++ b/dashboard/src/routes/groups.ts
@@ -5,6 +5,18 @@ import type { SignalClient } from '../../../bot/src/signalClient';
 export function createGroupRoutes(storage: Storage, signalClient: SignalClient): Router {
   const router = Router();
 
+  function enrichGroups(groups: Array<{ id: string; name: string; members: string[] }>) {
+    return groups.map((g) => {
+      const settings = storage.groupSettings.get(g.id);
+      return {
+        ...g,
+        enabled: settings ? settings.enabled : true,
+        activePersona: storage.personas.getActiveForGroup(g.id)?.name ?? 'Default',
+        settings,
+      };
+    });
+  }
+
   router.get('/groups', async (_req, res) => {
     try {
       const signalGroups = (await signalClient.listGroups()) as Array<{
@@ -12,16 +24,7 @@ export function createGroupRoutes(storage: Storage, signalClient: SignalClient):
         name: string;
         members: string[];
       }>;
-      const enriched = signalGroups.map((g) => {
-        const settings = storage.groupSettings.get(g.id);
-        return {
-          ...g,
-          enabled: settings ? settings.enabled : true,
-          activePersona: storage.personas.getActiveForGroup(g.id)?.name ?? 'Default',
-          settings,
-        };
-      });
-      res.json(enriched);
+      res.json(enrichGroups(signalGroups));
     } catch {
       res.status(503).json({ error: 'Could not fetch groups — signal-cli may be unreachable' });
     }
@@ -44,35 +47,24 @@ export function createGroupRoutes(storage: Storage, signalClient: SignalClient):
       return res.status(400).json({ error: 'Invalid Signal group invite link format' });
     }
     try {
-      // Snapshot group IDs before joining
       const beforeGroups = (await signalClient.listGroups()) as Array<{ id: string }>;
       const beforeIds = new Set(beforeGroups.map((g) => g.id));
 
       await signalClient.joinGroup(uri);
 
-      // Refresh group list after joining
       const signalGroups = (await signalClient.listGroups()) as Array<{
         id: string;
         name: string;
         members: string[];
       }>;
 
-      // Check if a new group appeared (admin-approval groups won't show up yet)
+      // Admin-approval groups won't appear in the list yet
       const newGroupFound = signalGroups.some((g) => !beforeIds.has(g.id));
       if (!newGroupFound) {
         return res.status(202).json({ message: 'Join request sent — awaiting admin approval' });
       }
 
-      const enriched = signalGroups.map((g) => {
-        const settings = storage.groupSettings.get(g.id);
-        return {
-          ...g,
-          enabled: settings ? settings.enabled : true,
-          activePersona: storage.personas.getActiveForGroup(g.id)?.name ?? 'Default',
-          settings,
-        };
-      });
-      res.json({ groups: enriched });
+      res.json({ groups: enrichGroups(signalGroups) });
     } catch (err) {
       const message = (err as Error).message || 'Unknown error';
       if (message.includes('Signal RPC error')) {

--- a/dashboard/src/routes/groups.ts
+++ b/dashboard/src/routes/groups.ts
@@ -63,5 +63,52 @@ export function createGroupRoutes(storage: Storage, signalClient: SignalClient):
     }
   });
 
+  router.post('/groups/join', async (req, res) => {
+    const { uri } = req.body;
+    if (!uri || typeof uri !== 'string' || !uri.startsWith('https://signal.group/#')) {
+      return res.status(400).json({ error: 'Invalid Signal group invite link format' });
+    }
+    try {
+      // Snapshot group IDs before joining
+      const beforeGroups = (await signalClient.listGroups()) as Array<{ id: string }>;
+      const beforeIds = new Set(beforeGroups.map((g) => g.id));
+
+      await signalClient.joinGroup(uri);
+
+      // Refresh group list after joining
+      const signalGroups = (await signalClient.listGroups()) as Array<{
+        id: string;
+        name: string;
+        members: string[];
+      }>;
+
+      // Check if a new group appeared (admin-approval groups won't show up yet)
+      const newGroupFound = signalGroups.some((g) => !beforeIds.has(g.id));
+      if (!newGroupFound) {
+        return res.status(202).json({ message: 'Join request sent — awaiting admin approval' });
+      }
+
+      const enriched = signalGroups.map((g) => {
+        const settings = storage.groupSettings.get(g.id);
+        return {
+          ...g,
+          enabled: settings ? settings.enabled : true,
+          activePersona: storage.personas.getActiveForGroup(g.id)?.name ?? 'Default',
+          settings,
+        };
+      });
+      res.json({ groups: enriched });
+    } catch (err) {
+      const message = (err as Error).message || 'Unknown error';
+      if (message.includes('Signal RPC error')) {
+        return res.status(422).json({ error: message });
+      }
+      if (message.includes('Signal API error')) {
+        return res.status(503).json({ error: 'Signal service unavailable' });
+      }
+      res.status(500).json({ error: 'Failed to join group' });
+    }
+  });
+
   return router;
 }

--- a/dashboard/src/routes/groups.ts
+++ b/dashboard/src/routes/groups.ts
@@ -38,31 +38,6 @@ export function createGroupRoutes(storage: Storage, signalClient: SignalClient):
     }
   });
 
-  router.post('/groups/:id/leave', async (req, res) => {
-    try {
-      await signalClient.quitGroup(req.params.id);
-      storage.groupSettings.upsert(req.params.id, { enabled: false });
-      res.json({ success: true });
-    } catch {
-      res.status(500).json({ error: 'Failed to leave group' });
-    }
-  });
-
-  router.patch('/groups/:id/settings', (req, res) => {
-    try {
-      const { enabled, customTriggers, contextWindowSize, toolNotifications } = req.body;
-      storage.groupSettings.upsert(req.params.id, {
-        enabled,
-        customTriggers,
-        contextWindowSize,
-        toolNotifications,
-      });
-      res.json(storage.groupSettings.get(req.params.id));
-    } catch {
-      res.status(500).json({ error: 'Failed to update settings' });
-    }
-  });
-
   router.post('/groups/join', async (req, res) => {
     const { uri } = req.body;
     if (!uri || typeof uri !== 'string' || !uri.startsWith('https://signal.group/#')) {
@@ -107,6 +82,31 @@ export function createGroupRoutes(storage: Storage, signalClient: SignalClient):
         return res.status(503).json({ error: 'Signal service unavailable' });
       }
       res.status(500).json({ error: 'Failed to join group' });
+    }
+  });
+
+  router.post('/groups/:id/leave', async (req, res) => {
+    try {
+      await signalClient.quitGroup(req.params.id);
+      storage.groupSettings.upsert(req.params.id, { enabled: false });
+      res.json({ success: true });
+    } catch {
+      res.status(500).json({ error: 'Failed to leave group' });
+    }
+  });
+
+  router.patch('/groups/:id/settings', (req, res) => {
+    try {
+      const { enabled, customTriggers, contextWindowSize, toolNotifications } = req.body;
+      storage.groupSettings.upsert(req.params.id, {
+        enabled,
+        customTriggers,
+        contextWindowSize,
+        toolNotifications,
+      });
+      res.json(storage.groupSettings.get(req.params.id));
+    } catch {
+      res.status(500).json({ error: 'Failed to update settings' });
     }
   });
 

--- a/dashboard/tests/routes/groups.test.ts
+++ b/dashboard/tests/routes/groups.test.ts
@@ -26,6 +26,7 @@ describe('groups routes', () => {
       listGroups: vi.fn(),
       getGroup: vi.fn(),
       quitGroup: vi.fn(),
+      joinGroup: vi.fn(),
     };
 
     app.use('/api', createGroupRoutes(mockStorage, mockSignalClient));
@@ -92,5 +93,96 @@ describe('groups routes', () => {
     expect(res.body.success).toBe(true);
     expect(mockSignalClient.quitGroup).toHaveBeenCalledWith('g1');
     expect(mockStorage.groupSettings.upsert).toHaveBeenCalledWith('g1', { enabled: false });
+  });
+
+  describe('POST /api/groups/join', () => {
+    it('joins group and returns refreshed group list', async () => {
+      mockSignalClient.joinGroup.mockResolvedValue(undefined);
+      mockSignalClient.listGroups
+        .mockResolvedValueOnce([{ id: 'g1', name: 'Family', members: ['+1'] }])
+        .mockResolvedValueOnce([
+          { id: 'g1', name: 'Family', members: ['+1'] },
+          { id: 'g2', name: 'New Group', members: ['+1', '+2'] },
+        ]);
+      mockStorage.groupSettings.get.mockReturnValue(null);
+      mockStorage.personas.getActiveForGroup.mockReturnValue(null);
+
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({ uri: 'https://signal.group/#abc123' });
+
+      expect(res.status).toBe(200);
+      expect(mockSignalClient.joinGroup).toHaveBeenCalledWith('https://signal.group/#abc123');
+      expect(res.body.groups).toHaveLength(2);
+    });
+
+    it('returns 202 when group not found after join (admin approval pending)', async () => {
+      mockSignalClient.joinGroup.mockResolvedValue(undefined);
+      // listGroups called twice: before join (1 group) and after join (still 1 group — new group not yet visible)
+      mockSignalClient.listGroups
+        .mockResolvedValueOnce([{ id: 'g1', name: 'Family', members: ['+1'] }])
+        .mockResolvedValueOnce([{ id: 'g1', name: 'Family', members: ['+1'] }]);
+      mockStorage.groupSettings.get.mockReturnValue(null);
+      mockStorage.personas.getActiveForGroup.mockReturnValue(null);
+
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({ uri: 'https://signal.group/#needs-approval' });
+
+      expect(res.status).toBe(202);
+      expect(res.body.message).toMatch(/awaiting admin approval/);
+    });
+
+    it('returns 400 for missing uri', async () => {
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Invalid Signal group invite link/);
+    });
+
+    it('returns 400 for malformed uri', async () => {
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({ uri: 'https://example.com/not-a-signal-link' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Invalid Signal group invite link/);
+    });
+
+    it('returns 422 when signal-cli rejects the link', async () => {
+      mockSignalClient.listGroups.mockResolvedValue([]);
+      mockSignalClient.joinGroup.mockRejectedValue(new Error('Signal RPC error: Invalid group link'));
+
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({ uri: 'https://signal.group/#expired' });
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toMatch(/Invalid group link/);
+    });
+
+    it('returns 500 on unexpected errors', async () => {
+      mockSignalClient.listGroups.mockResolvedValue([]);
+      mockSignalClient.joinGroup.mockRejectedValue(new TypeError('Cannot read properties of undefined'));
+
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({ uri: 'https://signal.group/#abc123' });
+
+      expect(res.status).toBe(500);
+    });
+
+    it('returns 503 when signal-cli is unreachable', async () => {
+      mockSignalClient.listGroups.mockResolvedValue([]);
+      mockSignalClient.joinGroup.mockRejectedValue(new Error('Signal API error: ECONNREFUSED'));
+
+      const res = await request(app)
+        .post('/api/groups/join')
+        .send({ uri: 'https://signal.group/#abc123' });
+
+      expect(res.status).toBe(503);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `joinGroup(uri)` method to SignalClient for joining Signal groups via invite link
- New `POST /api/groups/join` dashboard API endpoint with validation, admin-approval detection (202), and proper error mapping (400/422/503/500)
- Join-group UI input on the dashboard Groups page with loading state and error/success feedback
- Exposes `setData` from `useApi` hook for optimistic UI updates

## Test plan
- [x] SignalClient `joinGroup` unit test
- [x] 7 route tests: success, admin approval 202, missing URI 400, malformed URI 400, signal-cli rejection 422, unexpected error 500, signal unavailable 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)