### PR TITLE
feat: fetch image attachments via HTTP with disk fallback

### DIFF
--- a/bot/src/messageHandler.ts
+++ b/bot/src/messageHandler.ts
@@ -136,7 +136,7 @@ export class MessageHandler {
       attachments: attachments.length > 0 ? attachments : undefined,
     });
 
-    this.ingestImageAttachments(groupId, sender, attachments, timestamp);
+    await this.ingestImageAttachments(groupId, sender, attachments, timestamp);
 
     if (!mentioned) {
       return;
@@ -152,10 +152,7 @@ export class MessageHandler {
     );
   }
 
-  async handleMessageBatch(
-    groupId: string,
-    messages: ExtractedMessage[],
-  ): Promise<void> {
+  async handleMessageBatch(groupId: string, messages: ExtractedMessage[]): Promise<void> {
     const validMessages: ExtractedMessage[] = [];
     for (const msg of messages) {
       if (this.appConfig.botPhoneNumber && msg.sender === this.appConfig.botPhoneNumber) {
@@ -209,7 +206,7 @@ export class MessageHandler {
     }
 
     for (const msg of validMessages) {
-      this.ingestImageAttachments(groupId, msg.sender, msg.attachments, msg.timestamp);
+      await this.ingestImageAttachments(groupId, msg.sender, msg.attachments, msg.timestamp);
     }
 
     if (mentionMessages.length === 0) {
@@ -319,19 +316,28 @@ export class MessageHandler {
     };
   }
 
-  private ingestImageAttachments(
+  private async ingestImageAttachments(
     groupId: string,
     sender: string,
     attachments: SignalAttachment[],
     timestamp: number,
-  ): void {
+  ): Promise<void> {
     for (const att of attachments) {
       if (att.contentType.startsWith('image/')) {
-        const file = this.signalClient.readAttachmentFile(this.appConfig.attachmentsDir, att.id);
-        if (!file) {
-          logger.debug(`Attachment file not found on disk: ${att.id}`);
+        // Try HTTP fetch first (works with signal-cli REST API)
+        let data = await this.signalClient.fetchAttachment(att.id);
+
+        // Fallback: try disk read (works when ATTACHMENTS_DIR points to signal-cli's storage)
+        if (!data) {
+          const file = this.signalClient.readAttachmentFile(this.appConfig.attachmentsDir, att.id);
+          data = file?.data ?? null;
+        }
+
+        if (!data) {
+          logger.warn(`Failed to retrieve image attachment ${att.id} via HTTP and disk`);
           continue;
         }
+
         this.storage.saveAttachment({
           id: att.id,
           groupId,
@@ -339,7 +345,7 @@ export class MessageHandler {
           contentType: att.contentType,
           size: att.size,
           filename: att.filename,
-          data: file.data,
+          data,
           timestamp,
         });
       }

--- a/bot/src/mock/signalServer.ts
+++ b/bot/src/mock/signalServer.ts
@@ -81,6 +81,7 @@ interface Envelope {
 }
 
 const messageQueue: Envelope[] = [];
+const attachmentStore = new Map<string, Buffer>();
 let isTyping = false;
 
 function createEnvelope(
@@ -112,6 +113,7 @@ function clearTypingLine() {
 
 function queueImageMessage(text: string): { attachmentId: string } {
   const attachmentId = `mock-img-${Date.now()}`;
+  attachmentStore.set(attachmentId, TEST_PNG);
   const attachDir = process.env.ATTACHMENTS_DIR || './data/signal-attachments';
   fs.mkdirSync(attachDir, { recursive: true });
   fs.writeFileSync(path.join(attachDir, attachmentId), TEST_PNG);
@@ -168,6 +170,20 @@ const handlers: Record<string, RpcHandler> = {
 };
 
 const server = http.createServer((req, res) => {
+  // REST endpoint: GET /v1/attachments/{id} — returns base64 JSON like signal-cli
+  if (req.method === 'GET' && req.url?.startsWith('/v1/attachments/')) {
+    const id = req.url.slice('/v1/attachments/'.length);
+    const data = attachmentStore.get(id);
+    if (!data) {
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: 'Attachment not found' }));
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ data: data.toString('base64') }));
+    return;
+  }
+
   if (req.method !== 'POST' || req.url !== '/api/v1/rpc') {
     res.writeHead(404);
     res.end();

--- a/bot/src/signalClient.ts
+++ b/bot/src/signalClient.ts
@@ -99,6 +99,21 @@ export class SignalClient {
     throw new Error(`signal-cli not reachable at ${this.baseUrl} after ${maxRetries} attempts`);
   }
 
+  async fetchAttachment(attachmentId: string): Promise<Buffer | null> {
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/attachments/${attachmentId}`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!response.ok) return null;
+      const json = (await response.json()) as { data?: string };
+      if (!json.data) return null;
+      return Buffer.from(json.data, 'base64');
+    } catch {
+      return null;
+    }
+  }
+
   readAttachmentFile(attachmentsDir: string, attachmentId: string): { data: Buffer } | null {
     const filePath = path.resolve(attachmentsDir, attachmentId);
     if (!filePath.startsWith(path.resolve(attachmentsDir))) return null;

--- a/bot/tests/messageHandler.batch.test.ts
+++ b/bot/tests/messageHandler.batch.test.ts
@@ -60,7 +60,11 @@ describe('MessageHandler.handleMessageBatch', () => {
       getDossiersByGroup: vi.fn().mockReturnValue([]),
       getMemoriesByGroup: vi.fn().mockReturnValue([]),
       getActivePersonaForGroup: vi.fn().mockReturnValue(null),
-      groupSettings: { getToolNotifications: vi.fn().mockReturnValue(false), isEnabled: vi.fn().mockReturnValue(true), getTriggers: vi.fn().mockReturnValue(null) },
+      groupSettings: {
+        getToolNotifications: vi.fn().mockReturnValue(false),
+        isEnabled: vi.fn().mockReturnValue(true),
+        getTriggers: vi.fn().mockReturnValue(null),
+      },
     } as any;
 
     mockLLM = {
@@ -76,6 +80,8 @@ describe('MessageHandler.handleMessageBatch', () => {
       sendMessage: vi.fn().mockResolvedValue(undefined),
       sendTyping: vi.fn().mockResolvedValue(undefined),
       stopTyping: vi.fn().mockResolvedValue(undefined),
+      fetchAttachment: vi.fn().mockResolvedValue(null),
+      readAttachmentFile: vi.fn().mockReturnValue(null),
     } as any;
 
     handler = new MessageHandler(['claude:'], {

--- a/bot/tests/messageHandler.maintenance.test.ts
+++ b/bot/tests/messageHandler.maintenance.test.ts
@@ -52,7 +52,11 @@ describe('MessageHandler maintenance', () => {
       getMemoriesByGroup: vi.fn().mockReturnValue([]),
       getActivePersonaForGroup: vi.fn().mockReturnValue(null),
       saveAttachment: vi.fn(),
-      groupSettings: { getToolNotifications: vi.fn().mockReturnValue(false), isEnabled: vi.fn().mockReturnValue(true), getTriggers: vi.fn().mockReturnValue(null) },
+      groupSettings: {
+        getToolNotifications: vi.fn().mockReturnValue(false),
+        isEnabled: vi.fn().mockReturnValue(true),
+        getTriggers: vi.fn().mockReturnValue(null),
+      },
     } as any;
 
     mockLLM = {
@@ -68,6 +72,7 @@ describe('MessageHandler maintenance', () => {
       sendMessage: vi.fn().mockResolvedValue(undefined),
       sendTyping: vi.fn().mockResolvedValue(undefined),
       stopTyping: vi.fn().mockResolvedValue(undefined),
+      fetchAttachment: vi.fn().mockResolvedValue(null),
       readAttachmentFile: vi.fn().mockReturnValue(null),
     } as any;
   });
@@ -126,7 +131,7 @@ describe('MessageHandler maintenance', () => {
   describe('attachment ingestion', () => {
     it('should ingest attachments when handleMessageBatch is called', async () => {
       const fakeBuffer = Buffer.from('fake image');
-      mockSignal.readAttachmentFile = vi.fn().mockReturnValue({ data: fakeBuffer });
+      mockSignal.fetchAttachment = vi.fn().mockResolvedValue(fakeBuffer);
 
       const handler = new MessageHandler(['@bot'], {
         storage: mockStorage,
@@ -144,7 +149,7 @@ describe('MessageHandler maintenance', () => {
         },
       ]);
 
-      expect(mockSignal.readAttachmentFile).toHaveBeenCalledWith('/data/attachments', 'img-abc');
+      expect(mockSignal.fetchAttachment).toHaveBeenCalledWith('img-abc');
       expect(mockStorage.saveAttachment).toHaveBeenCalled();
     });
   });

--- a/bot/tests/messageHandler.test.ts
+++ b/bot/tests/messageHandler.test.ts
@@ -68,6 +68,7 @@ describe('MessageHandler', () => {
         sendMessage: vi.fn().mockResolvedValue(undefined),
         sendTyping: vi.fn().mockResolvedValue(undefined),
         stopTyping: vi.fn().mockResolvedValue(undefined),
+        fetchAttachment: vi.fn().mockResolvedValue(null),
         readAttachmentFile: vi.fn().mockReturnValue(null),
       } as any;
     });
@@ -919,8 +920,35 @@ describe('MessageHandler', () => {
     });
 
     describe('image attachment ingestion', () => {
-      it('should save image attachment data to storage on receive', async () => {
+      it('should save image attachment via HTTP fetch', async () => {
         const fakeBuffer = Buffer.from('fake image');
+        mockSignal.fetchAttachment = vi.fn().mockResolvedValue(fakeBuffer);
+
+        const handler = new MessageHandler(['@bot'], {
+          storage: mockStorage,
+          llmClient: mockLLM,
+          signalClient: mockSignal,
+          appConfig: makeAppConfig({ attachmentsDir: '/data/attachments' }),
+        });
+
+        await handler.handleMessage('g1', 'Alice', '@bot check this', 1000, [
+          { id: 'img-abc', contentType: 'image/jpeg', size: 50000, filename: 'photo.jpg' },
+        ]);
+
+        expect(mockSignal.fetchAttachment).toHaveBeenCalledWith('img-abc');
+        expect(mockStorage.saveAttachment).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'img-abc',
+            groupId: 'g1',
+            contentType: 'image/jpeg',
+            data: fakeBuffer,
+          }),
+        );
+      });
+
+      it('should fall back to disk read when HTTP fetch returns null', async () => {
+        const fakeBuffer = Buffer.from('disk image');
+        mockSignal.fetchAttachment = vi.fn().mockResolvedValue(null);
         mockSignal.readAttachmentFile = vi.fn().mockReturnValue({ data: fakeBuffer });
 
         const handler = new MessageHandler(['@bot'], {
@@ -934,18 +962,18 @@ describe('MessageHandler', () => {
           { id: 'img-abc', contentType: 'image/jpeg', size: 50000, filename: 'photo.jpg' },
         ]);
 
+        expect(mockSignal.fetchAttachment).toHaveBeenCalledWith('img-abc');
         expect(mockSignal.readAttachmentFile).toHaveBeenCalledWith('/data/attachments', 'img-abc');
         expect(mockStorage.saveAttachment).toHaveBeenCalledWith(
           expect.objectContaining({
             id: 'img-abc',
-            groupId: 'g1',
-            contentType: 'image/jpeg',
             data: fakeBuffer,
           }),
         );
       });
 
-      it('should not crash when attachment file is missing', async () => {
+      it('should not crash when both HTTP and disk fail', async () => {
+        mockSignal.fetchAttachment = vi.fn().mockResolvedValue(null);
         mockSignal.readAttachmentFile = vi.fn().mockReturnValue(null);
 
         const handler = new MessageHandler(['@bot'], {
@@ -962,7 +990,7 @@ describe('MessageHandler', () => {
       });
 
       it('should skip non-image attachments during ingestion', async () => {
-        mockSignal.readAttachmentFile = vi.fn();
+        mockSignal.fetchAttachment = vi.fn();
 
         const handler = new MessageHandler(['@bot'], {
           storage: mockStorage,
@@ -974,8 +1002,26 @@ describe('MessageHandler', () => {
           { id: 'voice-abc', contentType: 'audio/aac', size: 5000, filename: null },
         ]);
 
-        expect(mockSignal.readAttachmentFile).not.toHaveBeenCalled();
+        expect(mockSignal.fetchAttachment).not.toHaveBeenCalled();
         expect(mockStorage.saveAttachment).not.toHaveBeenCalled();
+      });
+
+      it('should not wait for disk fallback when HTTP succeeds', async () => {
+        const fakeBuffer = Buffer.from('http image');
+        mockSignal.fetchAttachment = vi.fn().mockResolvedValue(fakeBuffer);
+        mockSignal.readAttachmentFile = vi.fn();
+
+        const handler = new MessageHandler(['@bot'], {
+          storage: mockStorage,
+          llmClient: mockLLM,
+          signalClient: mockSignal,
+        });
+
+        await handler.handleMessage('g1', 'Alice', '@bot check this', 1000, [
+          { id: 'img-abc', contentType: 'image/jpeg', size: 50000, filename: 'photo.jpg' },
+        ]);
+
+        expect(mockSignal.readAttachmentFile).not.toHaveBeenCalled();
       });
     });
 

--- a/bot/tests/signalClient.fetchAttachment.test.ts
+++ b/bot/tests/signalClient.fetchAttachment.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignalClient } from '../src/signalClient';
+
+vi.mock('../src/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    group: vi.fn(),
+    step: vi.fn(),
+    groupEnd: vi.fn(),
+    compact: vi.fn(),
+  },
+}));
+
+describe('SignalClient.fetchAttachment', () => {
+  let client: SignalClient;
+  const baseUrl = 'http://localhost:8080';
+
+  beforeEach(() => {
+    client = new SignalClient(baseUrl, '+1234567890');
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return Buffer when HTTP returns valid base64 JSON', async () => {
+    const imageData = Buffer.from('fake image data');
+    const base64 = imageData.toString('base64');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: base64 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.fetchAttachment('att-123');
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result).toEqual(imageData);
+  });
+
+  it('should call correct URL', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ data: 'AAAA' }), { status: 200 }));
+
+    await client.fetchAttachment('att-456');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${baseUrl}/v1/attachments/att-456`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('should return null on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+    const result = await client.fetchAttachment('missing-id');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await client.fetchAttachment('att-123');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when response JSON has no data field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'no such attachment' }), { status: 200 }),
+    );
+
+    const result = await client.fetchAttachment('att-123');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when response is not valid JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not json', { status: 200 }));
+
+    const result = await client.fetchAttachment('att-123');
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `SignalClient.fetchAttachment()` to retrieve image attachments from signal-cli's REST API (`GET /v1/attachments/{id}`)
- Message handler now tries HTTP fetch first, falls back to disk read — works reliably with both REST API and local storage
- Mock signal server updated with in-memory attachment store and matching REST endpoint

## Test plan
- [x] Existing attachment ingestion tests updated for HTTP-first flow
- [x] New test: disk fallback when HTTP returns null
- [x] New test: no disk attempt when HTTP succeeds
- [x] New `signalClient.fetchAttachment.test.ts` unit tests
- [ ] Manual test with mock server (`npm run dev:mock`) — send image, verify ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)