### PR TITLE
Add edit_web_app and create_web_app tools (#65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Image attachments sent in Signal messages are stored as BLOBs in the `attachment
 - `signal.ts` — Send messages and images via Signal (2 tools)
 - `images.ts` — View image attachments stored in DB (1 tool)
 - `personas.ts` — Bot persona CRUD + switching (6 tools)
+- `webApps.ts` — create/write/edit/read web app sites, preview locally, deploy to Azure Static Web Apps (9 tools)
 
 ### Adding a New MCP Server
 1. Create `bot/src/mcp/servers/newThing.ts` using shared `ok()`, `error()`, `requireString()`, etc.

--- a/bot/src/contextBuilder.ts
+++ b/bot/src/contextBuilder.ts
@@ -32,7 +32,7 @@ const CAPABILITIES_PROMPT = `## Your Capabilities
 - Feature requests (create_feature_request) — file ideas via GitHub
 - Reminders (set_reminder, list_reminders, cancel_reminder) — schedule one-time or recurring reminders
 - Weather (get_weather_observations, get_weather_forecast) — Australian weather via BOM
-- Web apps (write_web_app, read_web_app, list_sites, delete_site, preview_web_app, deploy_web_apps) — build single-file HTML/JS/CSS websites, preview locally, and deploy to Azure Static Web Apps. Use preview_web_app + Playwright to visually test before deploying. After deploy, share the live URL with the group.
+- Web apps (create_web_app, write_web_app, edit_web_app, read_web_app, list_sites, delete_site, preview_web_app, deploy_web_apps) — build multi-file HTML/CSS/JS websites. Use create_web_app to start new sites (scaffolds index.html, styles.css, app.js). Use edit_web_app for surgical changes to existing files (find-and-replace). Use write_web_app to create or overwrite whole files. Use preview_web_app + Playwright to visually test before deploying. After deploy, share the live URL with the group.
 When someone shares personal info, you may update their dossier. When the group decides something worth remembering, save it as a memory.`;
 
 const COLLABORATIVE_TESTING_PROMPT = `## Collaborative Testing Mode

--- a/bot/src/mcp/servers/webApps.ts
+++ b/bot/src/mcp/servers/webApps.ts
@@ -60,6 +60,13 @@ function getSiteDir(siteName: string): string {
   return path.join(sitesDir, siteName);
 }
 
+function validateFilename(filename: string): string | null {
+  if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+    return 'Invalid filename. Path traversal not allowed.';
+  }
+  return null;
+}
+
 function humanizeName(siteName: string): string {
   return siteName
     .split('-')
@@ -347,9 +354,8 @@ export const webAppsServer: McpServerDefinition = {
         }
 
         const filename = optionalString(args, 'filename', 'index.html');
-        if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
-          return error('Invalid filename. Path traversal not allowed.');
-        }
+        const filenameError = validateFilename(filename);
+        if (filenameError) return error(filenameError);
 
         const siteDir = getSiteDir(name.value);
         mkdirSync(siteDir, { recursive: true });
@@ -373,6 +379,9 @@ export const webAppsServer: McpServerDefinition = {
         }
 
         const filename = optionalString(args, 'filename', 'index.html');
+        const filenameError = validateFilename(filename);
+        if (filenameError) return error(filenameError);
+
         const filePath = path.join(siteDir, filename);
         if (!existsSync(filePath)) {
           return error(`File "${filename}" not found in site "${name.value}".`);
@@ -401,9 +410,8 @@ export const webAppsServer: McpServerDefinition = {
         }
 
         const filename = optionalString(args, 'filename', 'index.html');
-        if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
-          return error('Invalid filename. Path traversal not allowed.');
-        }
+        const filenameError = validateFilename(filename);
+        if (filenameError) return error(filenameError);
 
         const filePath = path.join(siteDir, filename);
         if (!existsSync(filePath)) {
@@ -412,7 +420,6 @@ export const webAppsServer: McpServerDefinition = {
 
         const content = readFileSync(filePath, 'utf-8');
 
-        // Count occurrences and track match position
         let count = 0;
         let matchIdx = -1;
         let searchFrom = 0;
@@ -421,6 +428,7 @@ export const webAppsServer: McpServerDefinition = {
           if (idx === -1) break;
           if (count === 0) matchIdx = idx;
           count++;
+          if (count > 1) break;
           searchFrom = idx + oldText.value.length;
         }
 
@@ -429,25 +437,19 @@ export const webAppsServer: McpServerDefinition = {
         }
         if (count > 1) {
           return error(
-            `Text found ${count} times in ${filename}. Provide more surrounding context to make the match unique.`,
+            `Text found multiple times in ${filename}. Provide more surrounding context to make the match unique.`,
           );
         }
 
         const updated = content.replace(oldText.value, newText.value);
         writeFileSync(filePath, updated, 'utf-8');
 
-        // Build context snippet: show ~3 lines around the edit
-        const editIdx = matchIdx;
-        const lines = updated.split('\n');
+        // Find the edit line in the original content (stable offset)
         let editLine = 0;
-        let charCount = 0;
-        for (let i = 0; i < lines.length; i++) {
-          charCount += lines[i].length + 1; // +1 for newline
-          if (charCount > editIdx) {
-            editLine = i;
-            break;
-          }
+        for (let i = 0; i < matchIdx; i++) {
+          if (content[i] === '\n') editLine++;
         }
+        const lines = updated.split('\n');
         const snippetStart = Math.max(0, editLine - 1);
         const snippetEnd = Math.min(lines.length, editLine + 2);
         const snippet = lines.slice(snippetStart, snippetEnd).join('\n');

--- a/bot/src/mcp/servers/webApps.ts
+++ b/bot/src/mcp/servers/webApps.ts
@@ -117,6 +117,34 @@ const TOOLS = [
     },
   },
   {
+    name: 'edit_web_app',
+    title: 'Edit Web App File',
+    description:
+      'Find and replace text in a web app file. The old_text must match exactly once in the file. Use this for surgical edits instead of rewriting entire files.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        site_name: {
+          type: 'string',
+          description: 'Site name to edit',
+        },
+        filename: {
+          type: 'string',
+          description: 'Filename to edit. Defaults to "index.html".',
+        },
+        old_text: {
+          type: 'string',
+          description: 'Exact text to find (must appear exactly once in the file)',
+        },
+        new_text: {
+          type: 'string',
+          description: 'Replacement text',
+        },
+      },
+      required: ['site_name', 'old_text', 'new_text'],
+    },
+  },
+  {
     name: 'list_sites',
     title: 'List Web App Sites',
     description: 'List all web app sites with their files and sizes.',
@@ -285,6 +313,79 @@ export const webAppsServer: McpServerDefinition = {
         const content = readFileSync(filePath, 'utf-8');
         return ok(content);
       }, 'Failed to read web app');
+    },
+
+    edit_web_app(args) {
+      return catchErrors(() => {
+        const name = requireString(args, 'site_name');
+        if (name.error) return name.error;
+        const oldText = requireString(args, 'old_text');
+        if (oldText.error) return oldText.error;
+        const newText = requireString(args, 'new_text');
+        if (newText.error) return newText.error;
+
+        const nameError = validateSiteName(name.value);
+        if (nameError) return error(nameError);
+
+        const siteDir = getSiteDir(name.value);
+        if (!existsSync(siteDir)) {
+          return error(`Site "${name.value}" not found.`);
+        }
+
+        const filename = optionalString(args, 'filename', 'index.html');
+        if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+          return error('Invalid filename. Path traversal not allowed.');
+        }
+
+        const filePath = path.join(siteDir, filename);
+        if (!existsSync(filePath)) {
+          return error(`File "${filename}" not found in site "${name.value}".`);
+        }
+
+        const content = readFileSync(filePath, 'utf-8');
+
+        // Count occurrences
+        let count = 0;
+        let searchFrom = 0;
+        while (true) {
+          const idx = content.indexOf(oldText.value, searchFrom);
+          if (idx === -1) break;
+          count++;
+          searchFrom = idx + oldText.value.length;
+        }
+
+        if (count === 0) {
+          return error(`Text not found in ${filename}. Check for exact whitespace/indentation match.`);
+        }
+        if (count > 1) {
+          return error(
+            `Text found ${count} times in ${filename}. Provide more surrounding context to make the match unique.`,
+          );
+        }
+
+        const updated = content.replace(oldText.value, newText.value);
+        writeFileSync(filePath, updated, 'utf-8');
+
+        // Build context snippet: show ~3 lines around the edit
+        const editIdx = updated.indexOf(newText.value);
+        const lines = updated.split('\n');
+        let editLine = 0;
+        let charCount = 0;
+        for (let i = 0; i < lines.length; i++) {
+          charCount += lines[i].length + 1; // +1 for newline
+          if (charCount > editIdx) {
+            editLine = i;
+            break;
+          }
+        }
+        const snippetStart = Math.max(0, editLine - 1);
+        const snippetEnd = Math.min(lines.length, editLine + 2);
+        const snippet = lines.slice(snippetStart, snippetEnd).join('\n');
+
+        return ok(
+          `Edited ${filename} in site "${name.value}" (${updated.length} bytes).\n\nContext:\n${snippet}`,
+        );
+      }, 'Failed to edit web app');
     },
 
     list_sites() {

--- a/bot/src/mcp/servers/webApps.ts
+++ b/bot/src/mcp/servers/webApps.ts
@@ -344,12 +344,14 @@ export const webAppsServer: McpServerDefinition = {
 
         const content = readFileSync(filePath, 'utf-8');
 
-        // Count occurrences
+        // Count occurrences and track match position
         let count = 0;
+        let matchIdx = -1;
         let searchFrom = 0;
         while (true) {
           const idx = content.indexOf(oldText.value, searchFrom);
           if (idx === -1) break;
+          if (count === 0) matchIdx = idx;
           count++;
           searchFrom = idx + oldText.value.length;
         }
@@ -367,7 +369,7 @@ export const webAppsServer: McpServerDefinition = {
         writeFileSync(filePath, updated, 'utf-8');
 
         // Build context snippet: show ~3 lines around the edit
-        const editIdx = updated.indexOf(newText.value);
+        const editIdx = matchIdx;
         const lines = updated.split('\n');
         let editLine = 0;
         let charCount = 0;

--- a/bot/src/mcp/servers/webApps.ts
+++ b/bot/src/mcp/servers/webApps.ts
@@ -93,8 +93,7 @@ const TOOLS = [
         },
         title: {
           type: 'string',
-          description:
-            'Page title. Defaults to humanized site name (e.g. "birthday-card" becomes "Birthday Card").',
+          description: 'Page title. Defaults to humanized site name (e.g. "birthday-card" becomes "Birthday Card").',
         },
       },
       required: ['site_name'],
@@ -329,9 +328,7 @@ export const webAppsServer: McpServerDefinition = {
         writeFileSync(path.join(siteDir, 'styles.css'), `/* Styles for ${title} */\n`, 'utf-8');
         writeFileSync(path.join(siteDir, 'app.js'), `// App logic for ${title}\n`, 'utf-8');
 
-        return ok(
-          `Created site "${name.value}" with files:\n- index.html\n- styles.css\n- app.js`,
-        );
+        return ok(`Created site "${name.value}" with files:\n- index.html\n- styles.css\n- app.js`);
       }, 'Failed to create web app');
     },
 
@@ -455,9 +452,7 @@ export const webAppsServer: McpServerDefinition = {
         const snippetEnd = Math.min(lines.length, editLine + 2);
         const snippet = lines.slice(snippetStart, snippetEnd).join('\n');
 
-        return ok(
-          `Edited ${filename} in site "${name.value}" (${updated.length} bytes).\n\nContext:\n${snippet}`,
-        );
+        return ok(`Edited ${filename} in site "${name.value}" (${updated.length} bytes).\n\nContext:\n${snippet}`);
       }, 'Failed to edit web app');
     },
 
@@ -585,13 +580,43 @@ export const webAppsServer: McpServerDefinition = {
 
           try {
             // SWA requires a root index.html — auto-generate a landing page
-            const siteLinks = entries.map(e => `<li><a href="/${e.name}/">${e.name}</a></li>`).join('\n        ');
+            const siteCards = entries
+              .map(e => {
+                const sd = path.join(sitesDir, e.name);
+                const files = readdirSync(sd);
+                const totalSize = files.reduce((sum, f) => {
+                  const stat = statSync(path.join(sd, f));
+                  return sum + stat.size;
+                }, 0);
+                const sizeKb = (totalSize / 1024).toFixed(1);
+                return `      <a href="/${e.name}/" class="card">
+        <h2>${e.name}</h2>
+        <p class="files">${files.join(', ')}</p>
+        <p class="size">${sizeKb} KB</p>
+      </a>`;
+              })
+              .join('\n');
+
             const rootIndex = `<!DOCTYPE html>
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Signal Bot Sites</title>
-<style>*{margin:0;padding:0;box-sizing:border-box}body{font-family:system-ui,sans-serif;background:#1a1a2e;color:#e0e0e0;min-height:100vh;display:flex;justify-content:center;align-items:center}
-.wrap{max-width:400px;text-align:center}h1{margin-bottom:1.5rem;color:#7c3aed}ul{list-style:none}li{margin:.5rem 0}a{color:#60a5fa;text-decoration:none;font-size:1.2rem}a:hover{text-decoration:underline}</style>
-</head><body><div class="wrap"><h1>Signal Bot Sites</h1><ul>${siteLinks}</ul></div></body></html>`;
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:system-ui,sans-serif;background:#1a1a2e;color:#e0e0e0;min-height:100vh;padding:2rem}
+h1{text-align:center;color:#7c3aed;margin-bottom:2rem;font-size:1.8rem}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:1.5rem;max-width:960px;margin:0 auto}
+.card{display:block;background:#16213e;border-radius:12px;padding:1.5rem;text-decoration:none;color:#e0e0e0;transition:transform .15s,box-shadow .15s}
+.card:hover{transform:translateY(-3px);box-shadow:0 6px 20px rgba(124,58,237,.3)}
+.card h2{color:#60a5fa;font-size:1.2rem;margin-bottom:.5rem}
+.card .files{font-size:.85rem;color:#94a3b8;margin-bottom:.25rem}
+.card .size{font-size:.8rem;color:#64748b}
+</style>
+</head><body>
+<h1>Signal Bot Sites</h1>
+<div class="grid">
+${siteCards}
+</div>
+</body></html>`;
             writeFileSync(path.join(sitesDir, 'index.html'), rootIndex, 'utf-8');
 
             const swaBin = resolveSwaCliPath();

--- a/bot/src/mcp/servers/webApps.ts
+++ b/bot/src/mcp/servers/webApps.ts
@@ -60,6 +60,13 @@ function getSiteDir(siteName: string): string {
   return path.join(sitesDir, siteName);
 }
 
+function humanizeName(siteName: string): string {
+  return siteName
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 function stopPreviewServer(): void {
   if (previewTimer) {
     clearTimeout(previewTimer);
@@ -72,6 +79,27 @@ function stopPreviewServer(): void {
 }
 
 const TOOLS = [
+  {
+    name: 'create_web_app',
+    title: 'Create Web App',
+    description:
+      'Create a new web app site with HTML/CSS/JS scaffold. Errors if the site name is already taken. Use this to start new sites, then edit_web_app or write_web_app to add content.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        site_name: {
+          type: 'string',
+          description: 'Site name (lowercase letters, numbers, hyphens). e.g. "timer", "todo-app"',
+        },
+        title: {
+          type: 'string',
+          description:
+            'Page title. Defaults to humanized site name (e.g. "birthday-card" becomes "Birthday Card").',
+        },
+      },
+      required: ['site_name'],
+    },
+  },
   {
     name: 'write_web_app',
     title: 'Write Web App File',
@@ -264,6 +292,49 @@ export const webAppsServer: McpServerDefinition = {
     WEB_APPS_DIR: 'webAppsDir',
   },
   handlers: {
+    create_web_app(args) {
+      return catchErrors(() => {
+        const name = requireString(args, 'site_name');
+        if (name.error) return name.error;
+
+        const nameError = validateSiteName(name.value);
+        if (nameError) return error(nameError);
+
+        const siteDir = getSiteDir(name.value);
+        if (existsSync(siteDir)) {
+          return error(
+            `Site "${name.value}" already exists. Choose a different name or use write_web_app to modify it.`,
+          );
+        }
+
+        const title = optionalString(args, 'title', humanizeName(name.value));
+
+        mkdirSync(siteDir, { recursive: true });
+
+        const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>${title}</h1>
+  <script src="app.js"></script>
+</body>
+</html>`;
+
+        writeFileSync(path.join(siteDir, 'index.html'), html, 'utf-8');
+        writeFileSync(path.join(siteDir, 'styles.css'), `/* Styles for ${title} */\n`, 'utf-8');
+        writeFileSync(path.join(siteDir, 'app.js'), `// App logic for ${title}\n`, 'utf-8');
+
+        return ok(
+          `Created site "${name.value}" with files:\n- index.html\n- styles.css\n- app.js`,
+        );
+      }, 'Failed to create web app');
+    },
+
     write_web_app(args) {
       return catchErrors(() => {
         const name = requireString(args, 'site_name');

--- a/bot/src/mcp/servers/webApps.ts
+++ b/bot/src/mcp/servers/webApps.ts
@@ -420,35 +420,21 @@ export const webAppsServer: McpServerDefinition = {
 
         const content = readFileSync(filePath, 'utf-8');
 
-        let count = 0;
-        let matchIdx = -1;
-        let searchFrom = 0;
-        while (true) {
-          const idx = content.indexOf(oldText.value, searchFrom);
-          if (idx === -1) break;
-          if (count === 0) matchIdx = idx;
-          count++;
-          if (count > 1) break;
-          searchFrom = idx + oldText.value.length;
-        }
-
-        if (count === 0) {
+        const parts = content.split(oldText.value);
+        if (parts.length === 1) {
           return error(`Text not found in ${filename}. Check for exact whitespace/indentation match.`);
         }
-        if (count > 1) {
+        if (parts.length > 2) {
           return error(
             `Text found multiple times in ${filename}. Provide more surrounding context to make the match unique.`,
           );
         }
 
-        const updated = content.replace(oldText.value, newText.value);
+        const matchIdx = parts[0].length;
+        const updated = parts[0] + newText.value + parts[1];
         writeFileSync(filePath, updated, 'utf-8');
 
-        // Find the edit line in the original content (stable offset)
-        let editLine = 0;
-        for (let i = 0; i < matchIdx; i++) {
-          if (content[i] === '\n') editLine++;
-        }
+        const editLine = parts[0].split('\n').length - 1;
         const lines = updated.split('\n');
         const snippetStart = Math.max(0, editLine - 1);
         const snippetEnd = Math.min(lines.length, editLine + 2);

--- a/bot/tests/mcp/webApps.test.ts
+++ b/bot/tests/mcp/webApps.test.ts
@@ -27,11 +27,13 @@ describe('webApps MCP server', () => {
   });
 
   describe('tool listing', () => {
-    it('should have 7 tools', () => {
-      expect(webAppsServer.tools).toHaveLength(7);
+    it('should have 9 tools', () => {
+      expect(webAppsServer.tools).toHaveLength(9);
       const names = webAppsServer.tools.map(t => t.name);
       expect(names).toContain('write_web_app');
       expect(names).toContain('read_web_app');
+      expect(names).toContain('edit_web_app');
+      expect(names).toContain('create_web_app');
       expect(names).toContain('list_sites');
       expect(names).toContain('delete_site');
       expect(names).toContain('preview_web_app');
@@ -162,6 +164,121 @@ describe('webApps MCP server', () => {
         filename: 'nope.js',
       });
       expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('edit_web_app', () => {
+    it('should replace text in a file', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'edit-test',
+        content: '<h1>Hello World</h1>\n<p>Some content here</p>',
+      });
+
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'edit-test',
+        old_text: 'Hello World',
+        new_text: 'Updated Title',
+      });
+      expect(result.isError).toBeFalsy();
+      const text = resultText(result);
+      expect(text).toContain('Updated Title');
+
+      const filePath = join(testDir, 'sites', 'edit-test', 'index.html');
+      const content = readFileSync(filePath, 'utf-8');
+      expect(content).toBe('<h1>Updated Title</h1>\n<p>Some content here</p>');
+    });
+
+    it('should edit a specific filename', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'edit-test',
+        filename: 'styles.css',
+        content: 'body { color: red; }',
+      });
+
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'edit-test',
+        filename: 'styles.css',
+        old_text: 'red',
+        new_text: 'blue',
+      });
+      expect(result.isError).toBeFalsy();
+
+      const filePath = join(testDir, 'sites', 'edit-test', 'styles.css');
+      expect(readFileSync(filePath, 'utf-8')).toBe('body { color: blue; }');
+    });
+
+    it('should default filename to index.html', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'edit-default',
+        content: '<p>original</p>',
+      });
+
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'edit-default',
+        old_text: 'original',
+        new_text: 'modified',
+      });
+      expect(result.isError).toBeFalsy();
+
+      const filePath = join(testDir, 'sites', 'edit-default', 'index.html');
+      expect(readFileSync(filePath, 'utf-8')).toBe('<p>modified</p>');
+    });
+
+    it('should error when old_text is not found', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'edit-notfound',
+        content: '<h1>Hello</h1>',
+      });
+
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'edit-notfound',
+        old_text: 'Goodbye',
+        new_text: 'Hi',
+      });
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain('not found');
+    });
+
+    it('should error when old_text matches multiple times', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'edit-ambiguous',
+        content: '<p>hello</p>\n<p>hello</p>\n<p>hello</p>',
+      });
+
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'edit-ambiguous',
+        old_text: 'hello',
+        new_text: 'bye',
+      });
+      expect(result.isError).toBe(true);
+      const text = resultText(result);
+      expect(text).toContain('3 times');
+    });
+
+    it('should error when site does not exist', async () => {
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'nonexistent',
+        old_text: 'a',
+        new_text: 'b',
+      });
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain('not found');
+    });
+
+    it('should error when file does not exist', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'edit-nofile',
+        content: '<h1>Hi</h1>',
+      });
+
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'edit-nofile',
+        filename: 'missing.js',
+        old_text: 'a',
+        new_text: 'b',
+      });
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain('not found');
     });
   });
 

--- a/bot/tests/mcp/webApps.test.ts
+++ b/bot/tests/mcp/webApps.test.ts
@@ -468,5 +468,33 @@ describe('webApps MCP server', () => {
       expect(result.isError).toBe(true);
       expect(resultText(result)).toContain('No sites');
     });
+
+    it('should generate a dashboard index.html with site cards', async () => {
+      await webAppsServer.handlers.write_web_app({ site_name: 'alpha', content: '<h1>A</h1>' });
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'beta',
+        filename: 'index.html',
+        content: '<h1>B</h1>',
+      });
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'beta',
+        filename: 'styles.css',
+        content: 'body {}',
+      });
+
+      // Deploy will fail (no real SWA CLI), but the index.html is generated before the CLI call
+      process.env.SWA_DEPLOYMENT_TOKEN = 'fake-token';
+      await webAppsServer.handlers.deploy_web_apps({}).catch(() => {});
+
+      const indexPath = join(testDir, 'sites', 'index.html');
+      expect(existsSync(indexPath)).toBe(true);
+
+      const html = readFileSync(indexPath, 'utf-8');
+      expect(html).toContain('Signal Bot Sites');
+      expect(html).toContain('alpha');
+      expect(html).toContain('beta');
+      // Should have card-like structure with file info
+      expect(html).toContain('index.html');
+    });
   });
 });

--- a/bot/tests/mcp/webApps.test.ts
+++ b/bot/tests/mcp/webApps.test.ts
@@ -280,6 +280,21 @@ describe('webApps MCP server', () => {
       expect(result.isError).toBe(true);
       expect(resultText(result)).toContain('not found');
     });
+
+    it('should reject path traversal in filename', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'traversal-test',
+        content: '<h1>Hi</h1>',
+      });
+      const result = await webAppsServer.handlers.edit_web_app({
+        site_name: 'traversal-test',
+        filename: '../etc/passwd',
+        old_text: 'a',
+        new_text: 'b',
+      });
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain('Path traversal');
+    });
   });
 
   describe('list_sites', () => {

--- a/bot/tests/mcp/webApps.test.ts
+++ b/bot/tests/mcp/webApps.test.ts
@@ -297,6 +297,83 @@ describe('webApps MCP server', () => {
     });
   });
 
+  describe('create_web_app', () => {
+    it('should scaffold a site with three files', async () => {
+      const result = await webAppsServer.handlers.create_web_app({
+        site_name: 'new-site',
+      });
+      expect(result.isError).toBeFalsy();
+      const text = resultText(result);
+      expect(text).toContain('new-site');
+      expect(text).toContain('index.html');
+      expect(text).toContain('styles.css');
+      expect(text).toContain('app.js');
+
+      const siteDir = join(testDir, 'sites', 'new-site');
+      expect(existsSync(join(siteDir, 'index.html'))).toBe(true);
+      expect(existsSync(join(siteDir, 'styles.css'))).toBe(true);
+      expect(existsSync(join(siteDir, 'app.js'))).toBe(true);
+    });
+
+    it('should use humanized site name as default title', async () => {
+      await webAppsServer.handlers.create_web_app({
+        site_name: 'birthday-card',
+      });
+
+      const html = readFileSync(join(testDir, 'sites', 'birthday-card', 'index.html'), 'utf-8');
+      expect(html).toContain('<title>Birthday Card</title>');
+      expect(html).toContain('Birthday Card');
+    });
+
+    it('should use custom title when provided', async () => {
+      await webAppsServer.handlers.create_web_app({
+        site_name: 'my-app',
+        title: 'My Awesome App',
+      });
+
+      const html = readFileSync(join(testDir, 'sites', 'my-app', 'index.html'), 'utf-8');
+      expect(html).toContain('<title>My Awesome App</title>');
+
+      const css = readFileSync(join(testDir, 'sites', 'my-app', 'styles.css'), 'utf-8');
+      expect(css).toContain('My Awesome App');
+
+      const js = readFileSync(join(testDir, 'sites', 'my-app', 'app.js'), 'utf-8');
+      expect(js).toContain('My Awesome App');
+    });
+
+    it('should error when site already exists', async () => {
+      await webAppsServer.handlers.write_web_app({
+        site_name: 'taken',
+        content: '<h1>Existing</h1>',
+      });
+
+      const result = await webAppsServer.handlers.create_web_app({
+        site_name: 'taken',
+      });
+      expect(result.isError).toBe(true);
+      const text = resultText(result);
+      expect(text).toContain('already exists');
+    });
+
+    it('should error for invalid site name', async () => {
+      const result = await webAppsServer.handlers.create_web_app({
+        site_name: '../bad',
+      });
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain('Invalid site_name');
+    });
+
+    it('should link styles.css and app.js in index.html', async () => {
+      await webAppsServer.handlers.create_web_app({
+        site_name: 'linked-test',
+      });
+
+      const html = readFileSync(join(testDir, 'sites', 'linked-test', 'index.html'), 'utf-8');
+      expect(html).toContain('styles.css');
+      expect(html).toContain('app.js');
+    });
+  });
+
   describe('list_sites', () => {
     it('should return empty when no sites', async () => {
       const result = await webAppsServer.handlers.list_sites({});

--- a/bot/tests/mcp/webApps.test.ts
+++ b/bot/tests/mcp/webApps.test.ts
@@ -252,7 +252,7 @@ describe('webApps MCP server', () => {
       });
       expect(result.isError).toBe(true);
       const text = resultText(result);
-      expect(text).toContain('3 times');
+      expect(text).toContain('multiple times');
     });
 
     it('should error when site does not exist', async () => {

--- a/docs/superpowers/plans/2026-04-11-edit-web-app.md
+++ b/docs/superpowers/plans/2026-04-11-edit-web-app.md
@@ -1,0 +1,701 @@
+# Edit Web App & Web App Tooling Improvements — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `edit_web_app` (find-and-replace) and `create_web_app` (scaffold with collision detection) tools, upgrade the deploy dashboard, and update system prompt guidance.
+
+**Architecture:** Two new tools added to the existing `webAppsServer` in `webApps.ts`, following the same handler pattern. The deploy dashboard template is upgraded inline. System prompt updated in `contextBuilder.ts`.
+
+**Tech Stack:** TypeScript, Node.js fs APIs, vitest
+
+---
+
+## File Map
+
+- **Modify:** `bot/src/mcp/servers/webApps.ts` — add `edit_web_app` and `create_web_app` tool definitions + handlers, upgrade dashboard HTML template in `deploy_web_apps`
+- **Modify:** `bot/src/contextBuilder.ts:35` — update web apps system prompt line
+- **Modify:** `bot/tests/mcp/webApps.test.ts` — add test suites for both new tools, update tool count assertion
+- **Modify:** `bot/src/mcp/servers/webApps.ts` (CLAUDE.md tool list reference) — no change needed, CLAUDE.md lists tool counts per server which will need updating
+
+---
+
+### Task 1: `edit_web_app` — Tests
+
+**Files:**
+- Modify: `bot/tests/mcp/webApps.test.ts`
+
+- [ ] **Step 1: Update tool count assertion**
+
+In the `tool listing` describe block, update the expected count and add the new tool name:
+
+```typescript
+it('should have 9 tools', () => {
+  expect(webAppsServer.tools).toHaveLength(9);
+  const names = webAppsServer.tools.map(t => t.name);
+  expect(names).toContain('write_web_app');
+  expect(names).toContain('read_web_app');
+  expect(names).toContain('edit_web_app');
+  expect(names).toContain('create_web_app');
+  expect(names).toContain('list_sites');
+  expect(names).toContain('delete_site');
+  expect(names).toContain('preview_web_app');
+  expect(names).toContain('stop_preview');
+  expect(names).toContain('deploy_web_apps');
+});
+```
+
+- [ ] **Step 2: Add `edit_web_app` test suite**
+
+Add this describe block after the `read_web_app` describe block:
+
+```typescript
+describe('edit_web_app', () => {
+  it('should replace text in a file', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'edit-test',
+      content: '<h1>Hello World</h1>\n<p>Some content here</p>',
+    });
+
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'edit-test',
+      old_text: 'Hello World',
+      new_text: 'Updated Title',
+    });
+    expect(result.isError).toBeFalsy();
+    const text = resultText(result);
+    expect(text).toContain('Updated Title');
+
+    const filePath = join(testDir, 'sites', 'edit-test', 'index.html');
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toBe('<h1>Updated Title</h1>\n<p>Some content here</p>');
+  });
+
+  it('should edit a specific filename', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'edit-test',
+      filename: 'styles.css',
+      content: 'body { color: red; }',
+    });
+
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'edit-test',
+      filename: 'styles.css',
+      old_text: 'red',
+      new_text: 'blue',
+    });
+    expect(result.isError).toBeFalsy();
+
+    const filePath = join(testDir, 'sites', 'edit-test', 'styles.css');
+    expect(readFileSync(filePath, 'utf-8')).toBe('body { color: blue; }');
+  });
+
+  it('should default filename to index.html', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'edit-default',
+      content: '<p>original</p>',
+    });
+
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'edit-default',
+      old_text: 'original',
+      new_text: 'modified',
+    });
+    expect(result.isError).toBeFalsy();
+
+    const filePath = join(testDir, 'sites', 'edit-default', 'index.html');
+    expect(readFileSync(filePath, 'utf-8')).toBe('<p>modified</p>');
+  });
+
+  it('should error when old_text is not found', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'edit-notfound',
+      content: '<h1>Hello</h1>',
+    });
+
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'edit-notfound',
+      old_text: 'Goodbye',
+      new_text: 'Hi',
+    });
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain('not found');
+  });
+
+  it('should error when old_text matches multiple times', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'edit-ambiguous',
+      content: '<p>hello</p>\n<p>hello</p>\n<p>hello</p>',
+    });
+
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'edit-ambiguous',
+      old_text: 'hello',
+      new_text: 'bye',
+    });
+    expect(result.isError).toBe(true);
+    const text = resultText(result);
+    expect(text).toContain('3 times');
+  });
+
+  it('should error when site does not exist', async () => {
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'nonexistent',
+      old_text: 'a',
+      new_text: 'b',
+    });
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain('not found');
+  });
+
+  it('should error when file does not exist', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'edit-nofile',
+      content: '<h1>Hi</h1>',
+    });
+
+    const result = await webAppsServer.handlers.edit_web_app({
+      site_name: 'edit-nofile',
+      filename: 'missing.js',
+      old_text: 'a',
+      new_text: 'b',
+    });
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain('not found');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: All new `edit_web_app` tests FAIL (handler doesn't exist yet). Existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bot/tests/mcp/webApps.test.ts
+git commit -m "test: add failing tests for edit_web_app tool"
+```
+
+---
+
+### Task 2: `edit_web_app` — Implementation
+
+**Files:**
+- Modify: `bot/src/mcp/servers/webApps.ts`
+
+- [ ] **Step 1: Add tool definition to TOOLS array**
+
+Add this object to the `TOOLS` array, after the `read_web_app` entry:
+
+```typescript
+{
+  name: 'edit_web_app',
+  title: 'Edit Web App File',
+  description:
+    'Find and replace text in a web app file. The old_text must match exactly once in the file. Use this for surgical edits instead of rewriting entire files.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      site_name: {
+        type: 'string',
+        description: 'Site name to edit',
+      },
+      filename: {
+        type: 'string',
+        description: 'Filename to edit. Defaults to "index.html".',
+      },
+      old_text: {
+        type: 'string',
+        description: 'Exact text to find (must appear exactly once in the file)',
+      },
+      new_text: {
+        type: 'string',
+        description: 'Replacement text',
+      },
+    },
+    required: ['site_name', 'old_text', 'new_text'],
+  },
+},
+```
+
+- [ ] **Step 2: Add handler**
+
+Add this handler to the `handlers` object, after the `read_web_app` handler:
+
+```typescript
+edit_web_app(args) {
+  return catchErrors(() => {
+    const name = requireString(args, 'site_name');
+    if (name.error) return name.error;
+    const oldText = requireString(args, 'old_text');
+    if (oldText.error) return oldText.error;
+    const newText = requireString(args, 'new_text');
+    if (newText.error) return newText.error;
+
+    const nameError = validateSiteName(name.value);
+    if (nameError) return error(nameError);
+
+    const siteDir = getSiteDir(name.value);
+    if (!existsSync(siteDir)) {
+      return error(`Site "${name.value}" not found.`);
+    }
+
+    const filename = optionalString(args, 'filename', 'index.html');
+    if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      return error('Invalid filename. Path traversal not allowed.');
+    }
+
+    const filePath = path.join(siteDir, filename);
+    if (!existsSync(filePath)) {
+      return error(`File "${filename}" not found in site "${name.value}".`);
+    }
+
+    const content = readFileSync(filePath, 'utf-8');
+
+    // Count occurrences
+    let count = 0;
+    let searchFrom = 0;
+    while (true) {
+      const idx = content.indexOf(oldText.value, searchFrom);
+      if (idx === -1) break;
+      count++;
+      searchFrom = idx + oldText.value.length;
+    }
+
+    if (count === 0) {
+      return error(`Text not found in ${filename}. Check for exact whitespace/indentation match.`);
+    }
+    if (count > 1) {
+      return error(
+        `Text found ${count} times in ${filename}. Provide more surrounding context to make the match unique.`,
+      );
+    }
+
+    const updated = content.replace(oldText.value, newText.value);
+    writeFileSync(filePath, updated, 'utf-8');
+
+    // Build context snippet: show ~3 lines around the edit
+    const editIdx = updated.indexOf(newText.value);
+    const lines = updated.split('\n');
+    let editLine = 0;
+    let charCount = 0;
+    for (let i = 0; i < lines.length; i++) {
+      charCount += lines[i].length + 1; // +1 for newline
+      if (charCount > editIdx) {
+        editLine = i;
+        break;
+      }
+    }
+    const snippetStart = Math.max(0, editLine - 1);
+    const snippetEnd = Math.min(lines.length, editLine + 2);
+    const snippet = lines.slice(snippetStart, snippetEnd).join('\n');
+
+    return ok(
+      `Edited ${filename} in site "${name.value}" (${updated.length} bytes).\n\nContext:\n${snippet}`,
+    );
+  }, 'Failed to edit web app');
+},
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: All `edit_web_app` tests PASS. All existing tests still PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bot/src/mcp/servers/webApps.ts
+git commit -m "feat: add edit_web_app tool for find-and-replace edits (#65)"
+```
+
+---
+
+### Task 3: `create_web_app` — Tests
+
+**Files:**
+- Modify: `bot/tests/mcp/webApps.test.ts`
+
+- [ ] **Step 1: Add `create_web_app` test suite**
+
+Add this describe block after the `edit_web_app` describe block:
+
+```typescript
+describe('create_web_app', () => {
+  it('should scaffold a site with three files', async () => {
+    const result = await webAppsServer.handlers.create_web_app({
+      site_name: 'new-site',
+    });
+    expect(result.isError).toBeFalsy();
+    const text = resultText(result);
+    expect(text).toContain('new-site');
+    expect(text).toContain('index.html');
+    expect(text).toContain('styles.css');
+    expect(text).toContain('app.js');
+
+    const siteDir = join(testDir, 'sites', 'new-site');
+    expect(existsSync(join(siteDir, 'index.html'))).toBe(true);
+    expect(existsSync(join(siteDir, 'styles.css'))).toBe(true);
+    expect(existsSync(join(siteDir, 'app.js'))).toBe(true);
+  });
+
+  it('should use humanized site name as default title', async () => {
+    await webAppsServer.handlers.create_web_app({
+      site_name: 'birthday-card',
+    });
+
+    const html = readFileSync(join(testDir, 'sites', 'birthday-card', 'index.html'), 'utf-8');
+    expect(html).toContain('<title>Birthday Card</title>');
+    expect(html).toContain('Birthday Card');
+  });
+
+  it('should use custom title when provided', async () => {
+    await webAppsServer.handlers.create_web_app({
+      site_name: 'my-app',
+      title: 'My Awesome App',
+    });
+
+    const html = readFileSync(join(testDir, 'sites', 'my-app', 'index.html'), 'utf-8');
+    expect(html).toContain('<title>My Awesome App</title>');
+
+    const css = readFileSync(join(testDir, 'sites', 'my-app', 'styles.css'), 'utf-8');
+    expect(css).toContain('My Awesome App');
+
+    const js = readFileSync(join(testDir, 'sites', 'my-app', 'app.js'), 'utf-8');
+    expect(js).toContain('My Awesome App');
+  });
+
+  it('should error when site already exists', async () => {
+    await webAppsServer.handlers.write_web_app({
+      site_name: 'taken',
+      content: '<h1>Existing</h1>',
+    });
+
+    const result = await webAppsServer.handlers.create_web_app({
+      site_name: 'taken',
+    });
+    expect(result.isError).toBe(true);
+    const text = resultText(result);
+    expect(text).toContain('already exists');
+  });
+
+  it('should error for invalid site name', async () => {
+    const result = await webAppsServer.handlers.create_web_app({
+      site_name: '../bad',
+    });
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain('Invalid site_name');
+  });
+
+  it('should link styles.css and app.js in index.html', async () => {
+    await webAppsServer.handlers.create_web_app({
+      site_name: 'linked-test',
+    });
+
+    const html = readFileSync(join(testDir, 'sites', 'linked-test', 'index.html'), 'utf-8');
+    expect(html).toContain('styles.css');
+    expect(html).toContain('app.js');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: All new `create_web_app` tests FAIL. All existing tests (including `edit_web_app`) PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bot/tests/mcp/webApps.test.ts
+git commit -m "test: add failing tests for create_web_app tool"
+```
+
+---
+
+### Task 4: `create_web_app` — Implementation
+
+**Files:**
+- Modify: `bot/src/mcp/servers/webApps.ts`
+
+- [ ] **Step 1: Add a `humanizeName` helper**
+
+Add this function after the `getSiteDir` function (around line 61):
+
+```typescript
+function humanizeName(siteName: string): string {
+  return siteName
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+```
+
+- [ ] **Step 2: Add tool definition to TOOLS array**
+
+Add this object to the `TOOLS` array, before the `write_web_app` entry (so it appears first in tool listings):
+
+```typescript
+{
+  name: 'create_web_app',
+  title: 'Create Web App',
+  description:
+    'Create a new web app site with HTML/CSS/JS scaffold. Errors if the site name is already taken. Use this to start new sites, then edit_web_app or write_web_app to add content.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      site_name: {
+        type: 'string',
+        description: 'Site name (lowercase letters, numbers, hyphens). e.g. "timer", "todo-app"',
+      },
+      title: {
+        type: 'string',
+        description:
+          'Page title. Defaults to humanized site name (e.g. "birthday-card" becomes "Birthday Card").',
+      },
+    },
+    required: ['site_name'],
+  },
+},
+```
+
+- [ ] **Step 3: Add handler**
+
+Add this handler to the `handlers` object, before the `write_web_app` handler:
+
+```typescript
+create_web_app(args) {
+  return catchErrors(() => {
+    const name = requireString(args, 'site_name');
+    if (name.error) return name.error;
+
+    const nameError = validateSiteName(name.value);
+    if (nameError) return error(nameError);
+
+    const siteDir = getSiteDir(name.value);
+    if (existsSync(siteDir)) {
+      return error(
+        `Site "${name.value}" already exists. Choose a different name or use write_web_app to modify it.`,
+      );
+    }
+
+    const title = optionalString(args, 'title', humanizeName(name.value));
+
+    mkdirSync(siteDir, { recursive: true });
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>${title}</h1>
+  <script src="app.js"></script>
+</body>
+</html>`;
+
+    writeFileSync(path.join(siteDir, 'index.html'), html, 'utf-8');
+    writeFileSync(path.join(siteDir, 'styles.css'), `/* Styles for ${title} */\n`, 'utf-8');
+    writeFileSync(path.join(siteDir, 'app.js'), `// App logic for ${title}\n`, 'utf-8');
+
+    return ok(
+      `Created site "${name.value}" with files:\n- index.html\n- styles.css\n- app.js`,
+    );
+  }, 'Failed to create web app');
+},
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: All `create_web_app` tests PASS. All other tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bot/src/mcp/servers/webApps.ts
+git commit -m "feat: add create_web_app tool with scaffold and collision detection"
+```
+
+---
+
+### Task 5: Dashboard Enhancement
+
+**Files:**
+- Modify: `bot/src/mcp/servers/webApps.ts`
+- Modify: `bot/tests/mcp/webApps.test.ts`
+
+- [ ] **Step 1: Add dashboard test**
+
+Add this test to the `deploy_web_apps` describe block, after the existing "should error when no sites exist" test:
+
+```typescript
+it('should generate a dashboard index.html with site cards', async () => {
+  await webAppsServer.handlers.write_web_app({ site_name: 'alpha', content: '<h1>A</h1>' });
+  await webAppsServer.handlers.write_web_app({
+    site_name: 'beta',
+    filename: 'index.html',
+    content: '<h1>B</h1>',
+  });
+  await webAppsServer.handlers.write_web_app({
+    site_name: 'beta',
+    filename: 'styles.css',
+    content: 'body {}',
+  });
+
+  // Deploy will fail (no real SWA CLI), but the index.html is generated before the CLI call
+  process.env.SWA_DEPLOYMENT_TOKEN = 'fake-token';
+  await webAppsServer.handlers.deploy_web_apps({}).catch(() => {});
+
+  const indexPath = join(testDir, 'sites', 'index.html');
+  expect(existsSync(indexPath)).toBe(true);
+
+  const html = readFileSync(indexPath, 'utf-8');
+  expect(html).toContain('Signal Bot Sites');
+  expect(html).toContain('alpha');
+  expect(html).toContain('beta');
+  // Should have card-like structure with file info
+  expect(html).toContain('index.html');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: The new dashboard test MAY pass already since an index.html is generated, but it should fail on the card structure assertions. Check the output.
+
+- [ ] **Step 3: Upgrade the dashboard template**
+
+In the `deploy_web_apps` handler, replace the `siteLinks` and `rootIndex` generation (the block that starts with `const siteLinks = entries.map(...)` and ends with the closing `</html>` template) with:
+
+```typescript
+const siteCards = entries
+  .map(e => {
+    const sd = path.join(sitesDir, e.name);
+    const files = readdirSync(sd);
+    const totalSize = files.reduce((sum, f) => {
+      const stat = statSync(path.join(sd, f));
+      return sum + stat.size;
+    }, 0);
+    const sizeKb = (totalSize / 1024).toFixed(1);
+    return `      <a href="/${e.name}/" class="card">
+        <h2>${e.name}</h2>
+        <p class="files">${files.join(', ')}</p>
+        <p class="size">${sizeKb} KB</p>
+      </a>`;
+  })
+  .join('\n');
+
+const rootIndex = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Signal Bot Sites</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:system-ui,sans-serif;background:#1a1a2e;color:#e0e0e0;min-height:100vh;padding:2rem}
+h1{text-align:center;color:#7c3aed;margin-bottom:2rem;font-size:1.8rem}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:1.5rem;max-width:960px;margin:0 auto}
+.card{display:block;background:#16213e;border-radius:12px;padding:1.5rem;text-decoration:none;color:#e0e0e0;transition:transform .15s,box-shadow .15s}
+.card:hover{transform:translateY(-3px);box-shadow:0 6px 20px rgba(124,58,237,.3)}
+.card h2{color:#60a5fa;font-size:1.2rem;margin-bottom:.5rem}
+.card .files{font-size:.85rem;color:#94a3b8;margin-bottom:.25rem}
+.card .size{font-size:.8rem;color:#64748b}
+</style>
+</head><body>
+<h1>Signal Bot Sites</h1>
+<div class="grid">
+${siteCards}
+</div>
+</body></html>`;
+```
+
+Note: the `readdirSync` and `statSync` imports are already at the top of the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: All tests PASS including the new dashboard test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bot/src/mcp/servers/webApps.ts bot/tests/mcp/webApps.test.ts
+git commit -m "feat: upgrade deploy dashboard to card grid layout"
+```
+
+---
+
+### Task 6: System Prompt Update
+
+**Files:**
+- Modify: `bot/src/contextBuilder.ts:35`
+
+- [ ] **Step 1: Update the web apps system prompt line**
+
+Replace the existing web apps line (line 35 in `contextBuilder.ts`):
+
+```
+- Web apps (write_web_app, read_web_app, list_sites, delete_site, preview_web_app, deploy_web_apps) — build single-file HTML/JS/CSS websites, preview locally, and deploy to Azure Static Web Apps. Use preview_web_app + Playwright to visually test before deploying. After deploy, share the live URL with the group.
+```
+
+With:
+
+```
+- Web apps (create_web_app, write_web_app, edit_web_app, read_web_app, list_sites, delete_site, preview_web_app, deploy_web_apps) — build multi-file HTML/CSS/JS websites. Use create_web_app to start new sites (scaffolds index.html, styles.css, app.js). Use edit_web_app for surgical changes to existing files (find-and-replace). Use write_web_app to create or overwrite whole files. Use preview_web_app + Playwright to visually test before deploying. After deploy, share the live URL with the group.
+```
+
+- [ ] **Step 2: Run lint and tests**
+
+Run: `cd bot && npm run check && npx vitest run`
+Expected: Lint passes. All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bot/src/contextBuilder.ts
+git commit -m "docs: update system prompt for new web app tools"
+```
+
+---
+
+### Task 7: CLAUDE.md Update
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add webApps server to MCP Servers list**
+
+The webApps server is missing from CLAUDE.md's MCP Servers section. Add it after the `personas.ts` line (line 58):
+
+```
+- `webApps.ts` — create/write/edit/read web app sites, preview locally, deploy to Azure Static Web Apps (9 tools)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add webApps server to CLAUDE.md MCP server list"
+```
+
+---
+
+### Task 8: Final Verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd bot && npx vitest run`
+Expected: All tests pass, zero failures.
+
+- [ ] **Step 2: Run lint and format check**
+
+Run: `cd bot && npm run check`
+Expected: No lint or format errors.
+
+- [ ] **Step 3: Verify tool count manually**
+
+Run: `cd bot && npx vitest run tests/mcp/webApps.test.ts`
+Expected: "9 tools" assertion passes, confirming both new tools are registered.

--- a/docs/superpowers/specs/2026-04-11-edit-web-app-design.md
+++ b/docs/superpowers/specs/2026-04-11-edit-web-app-design.md
@@ -1,0 +1,126 @@
+# Edit Web App & Web App Tooling Improvements
+
+**Date:** 2026-04-11
+**Issue:** #65 — Add edit_web_app tool for surgical find-and-replace edits
+**Approach:** Incremental tool addition to existing `webApps.ts` server
+
+## Context
+
+The web app feature (create websites via Signal chat) has become one of the most popular bot capabilities. The current toolset (`write_web_app`, `read_web_app`, `list_sites`, `delete_site`, `preview_web_app`, `deploy_web_apps`) works but has pain points:
+
+- Editing large files requires regenerating the entire file via `write_web_app`, which hits Claude's output token limit on files over ~600 lines.
+- No scaffolding — every new site starts from scratch, and Claude must generate all boilerplate.
+- No name collision detection — creating a site with an existing name silently overwrites it.
+- The auto-generated dashboard is a bare list of links.
+
+This is the first of several planned expansions to the web app feature.
+
+## Changes
+
+### 1. `edit_web_app` Tool
+
+Find-and-replace on a single file within a site, modeled on the Claude Code Edit tool.
+
+**Parameters:**
+- `site_name` (string, required) — target site
+- `filename` (string, optional, default `index.html`) — file to edit
+- `old_text` (string, required) — exact text to find
+- `new_text` (string, required) — replacement text
+
+**Behavior:**
+1. Validate site name and filename (same checks as existing tools).
+2. Read the file. Verify `old_text` appears exactly once. Error if not found or ambiguous.
+3. Replace the matched text with `new_text`.
+4. Write the file back.
+5. Return confirmation with a ~3-line context snippet around the edit location, plus the new file size.
+
+**Error messages:**
+- Not found: `"Text not found in {filename}. Check for exact whitespace/indentation match."`
+- Ambiguous: `"Text found {n} times in {filename}. Provide more surrounding context to make the match unique."`
+
+### 2. `create_web_app` Tool
+
+Scaffolds a new site with the standard HTML/CSS/JS three-file structure.
+
+**Parameters:**
+- `site_name` (string, required) — site name
+- `title` (string, optional, default: humanized site name, e.g. `birthday-card` → `Birthday Card`) — page title
+
+**Behavior:**
+1. Validate site name.
+2. Check if site directory already exists — hard error: `"Site '{name}' already exists. Choose a different name or use write_web_app to modify it."`
+3. Create directory with three files:
+   - `index.html` — minimal HTML5 skeleton with viewport meta, links `styles.css` and `app.js`, uses the title
+   - `styles.css` — empty with comment header `/* Styles for {title} */`
+   - `app.js` — empty with comment header `// App logic for {title}`
+4. Return confirmation listing the created files.
+
+The scaffold is intentionally bare — just the wiring between files. Claude fills in content via `write_web_app` or `edit_web_app`.
+
+### 3. No Changes to `write_web_app`
+
+`write_web_app` stays unchanged. It is intentionally idempotent — used for both creating and updating files. Adding collision detection would break the update workflow. The collision guard lives in `create_web_app`, which is the explicit "start a new project" action. System prompt guidance steers Claude toward `create_web_app` for new sites.
+
+### 4. Dashboard Enhancement
+
+Upgrade the auto-generated root `index.html` (created during `deploy_web_apps`) from a bare link list to a proper dashboard.
+
+**Dashboard content:**
+- Title: "Signal Bot Sites"
+- Card grid layout — one card per site showing:
+  - Site name (linked to the site)
+  - File list (e.g. "index.html, styles.css, app.js")
+  - Total size
+- Responsive, dark theme (consistent with existing styling direction)
+- Pure static HTML/CSS, no JS dependencies
+
+**What stays the same:**
+- Generated inline in the `deploy_web_apps` handler
+- Overwrites `sitesDir/index.html` on each deploy
+- No separate tool or build step
+
+### 5. System Prompt Update
+
+Update the web apps guidance in `contextBuilder.ts`:
+
+> Web apps (create_web_app, write_web_app, edit_web_app, read_web_app, list_sites, delete_site, preview_web_app, deploy_web_apps) — build multi-file HTML/CSS/JS websites. Use create_web_app to start new sites (scaffolds index.html, styles.css, app.js). Use edit_web_app for surgical changes to existing files (find-and-replace). Use write_web_app to create or overwrite whole files. Use preview_web_app + Playwright to visually test before deploying. After deploy, share the live URL with the group.
+
+Key shifts from current guidance:
+- Leads with `create_web_app` as the starting point
+- Positions `edit_web_app` as the default for changes
+- Mentions multi-file structure instead of "single-file"
+
+### 6. Testing
+
+All tests in `bot/tests/mcp/webApps.test.ts`, following existing patterns (isolated temp dirs, direct handler calls).
+
+**`edit_web_app` tests:**
+- Successful find-and-replace
+- `old_text` not found → error
+- `old_text` found multiple times → error with count
+- Site doesn't exist → error
+- File doesn't exist → error
+- Filename defaults to `index.html`
+
+**`create_web_app` tests:**
+- Creates three files (index.html, styles.css, app.js)
+- Title defaults to humanized site name
+- Custom title is used
+- Site already exists → hard error
+- Invalid site name → error
+
+**Dashboard tests:**
+- Deploy generates root `index.html` with card layout containing links to all sites
+
+## Files Changed
+
+- `bot/src/mcp/servers/webApps.ts` — add `edit_web_app` tool, `create_web_app` tool, upgrade dashboard template
+- `bot/src/contextBuilder.ts` — update web apps system prompt guidance
+- `bot/tests/mcp/webApps.test.ts` — add tests for new tools and dashboard
+
+## Out of Scope
+
+- Template variants (e.g. "game", "dashboard" scaffolds) — future expansion
+- Library management tools — Claude already knows CDN patterns
+- TypeScript support / build step — JS only for now
+- Auto-suffixing on name collision — hard error, Claude picks a new name

--- a/docs/web-app-tools-qa-report.md
+++ b/docs/web-app-tools-qa-report.md
@@ -1,0 +1,197 @@
+# Web App Tools QA Report
+
+**Date:** 2026-04-11
+**Branch:** `feature/edit-web-app`
+**Commit:** `7a0fc11` (fix: use string slicing in edit_web_app to avoid $-pattern corruption)
+
+## Summary
+
+Tested all 9 web app MCP tools across three test phases:
+
+1. **Unit tests (vitest):** 38/38 pass
+2. **Automated edge cases:** 28/30 pass (2 failures are a known design constraint)
+3. **Manual end-to-end:** Built a countdown timer app through the full tool lifecycle — all 9 tools exercised successfully
+
+---
+
+## Tool-by-Tool Results
+
+### 1. create_web_app
+
+| Test | Result |
+|------|--------|
+| Scaffolds index.html, styles.css, app.js | PASS |
+| Default title = humanized site name ("birthday-card" -> "Birthday Card") | PASS |
+| Custom title propagates to all 3 files | PASS |
+| Errors when site already exists | PASS |
+| Errors for invalid site name (path traversal) | PASS |
+| Links styles.css and app.js in index.html | PASS |
+| Errors when site_name missing | PASS |
+| Single-word name capitalizes correctly ("timer" -> "Timer") | PASS |
+
+**Status: ALL PASS**
+
+### 2. write_web_app
+
+| Test | Result |
+|------|--------|
+| Writes index.html for a site | PASS |
+| Writes custom filename | PASS |
+| Overwrites existing files | PASS |
+| Rejects invalid site names | PASS |
+| Rejects site names with spaces | PASS |
+| Rejects content exceeding 1MB | PASS |
+| Requires site_name parameter | PASS |
+| Requires content parameter | PASS |
+| Rejects path traversal in filename | PASS |
+
+**Status: ALL PASS**
+
+### 3. edit_web_app
+
+| Test | Result |
+|------|--------|
+| Replaces text in a file | PASS |
+| Edits specific filename (CSS) | PASS |
+| Defaults filename to index.html | PASS |
+| Errors when old_text not found | PASS |
+| Errors when old_text matches multiple times | PASS |
+| Errors when site does not exist | PASS |
+| Errors when file does not exist | PASS |
+| Rejects path traversal in filename | PASS |
+| $-pattern safety ($100, $&, $$, $1 in new_text) | PASS |
+| Multiline old_text/new_text replacement | PASS |
+| No-op edit (old_text === new_text) | PASS |
+| Delete text (new_text = "") | FAIL (known) |
+
+**Status: 11/12 PASS.** The empty `new_text` failure is a design constraint: `requireString` rejects empty strings by design across all MCP tools. Workaround: use `write_web_app` to rewrite the file without the unwanted text.
+
+### 4. read_web_app
+
+| Test | Result |
+|------|--------|
+| Reads back written content | PASS |
+| Reads specific filename | PASS |
+| Errors for non-existent site | PASS |
+| Errors for non-existent file | PASS |
+| Rejects path traversal in filename | PASS |
+
+**Status: ALL PASS**
+
+### 5. list_sites
+
+| Test | Result |
+|------|--------|
+| Returns "No sites" when empty | PASS |
+| Lists all created sites | PASS |
+| Reflects changes after create/delete | PASS |
+
+**Status: ALL PASS**
+
+### 6. delete_site
+
+| Test | Result |
+|------|--------|
+| Deletes existing site | PASS |
+| Removes directory from filesystem | PASS |
+| Errors for non-existent site | PASS |
+| Site gone from list_sites after deletion | PASS |
+
+**Status: ALL PASS**
+
+### 7. preview_web_app
+
+| Test | Result |
+|------|--------|
+| Starts local server, returns URL | PASS |
+| Serves correct file content at URL | PASS |
+| Errors for non-existent site | PASS |
+
+**Status: ALL PASS**
+
+### 8. stop_preview
+
+| Test | Result |
+|------|--------|
+| Stops running preview server | PASS |
+| Server unreachable after stop | PASS |
+| No-op when no preview running | PASS |
+
+**Status: ALL PASS**
+
+### 9. deploy_web_apps
+
+| Test | Result |
+|------|--------|
+| Errors when SWA_DEPLOYMENT_TOKEN not set | PASS |
+| Errors when no sites exist | PASS |
+| Generates dashboard index.html with site cards | PASS |
+
+**Status: ALL PASS** (deploy to real SWA not tested -- requires token and CLI)
+
+---
+
+## Cross-Tool Workflow Tests
+
+| Workflow | Result |
+|----------|--------|
+| create_web_app -> edit_web_app (HTML, CSS, JS) -> read_web_app -> list_sites | PASS |
+| write_web_app -> edit_web_app -> read_web_app | PASS |
+| create_web_app -> delete_site -> verify cleanup | PASS |
+| preview_web_app -> fetch content -> stop_preview | PASS |
+
+---
+
+## Manual End-to-End Test
+
+Built a "countdown-timer" app using the tools in sequence, simulating real bot usage:
+
+```
+1. create_web_app("countdown-timer")     → scaffolded index.html, styles.css, app.js
+2. read_web_app("countdown-timer")       → verified scaffold content
+3. edit_web_app (HTML, add timer UI)      → surgically inserted <div id="display">, buttons
+4. edit_web_app (CSS, add styles)         → replaced placeholder comment with full stylesheet
+5. edit_web_app (JS, add app logic)       → replaced placeholder comment with timer logic
+6. read_web_app (x3, all files)           → verified all edits persisted correctly
+7. list_sites                             → showed "countdown-timer" with 3 files, 1.6 KB
+8. write_web_app("hello-world")           → created second site from scratch
+9. list_sites                             → showed 2 sites
+10. preview_web_app("countdown-timer")    → started server on localhost:44707
+11. fetch index.html, styles.css, app.js  → all 200 OK, correct content served
+12. stop_preview                          → server stopped, confirmed unreachable
+13. delete_site("hello-world")            → removed site
+14. list_sites                            → confirmed only countdown-timer remains
+15. deploy_web_apps                       → generated dashboard index.html with card grid
+                                            (SWA CLI not installed — expected error)
+```
+
+**Result: All 15 steps completed successfully.** The full create → edit → read → preview → delete lifecycle works as intended.
+
+---
+
+## Security Tests
+
+| Test | Result |
+|------|--------|
+| write_web_app: path traversal in filename (`../../../etc/passwd`) | BLOCKED |
+| read_web_app: path traversal in filename (`../../etc/passwd`) | BLOCKED |
+| edit_web_app: path traversal in filename (`../etc/passwd`) | BLOCKED |
+| create_web_app: path traversal in site_name (`../bad`) | BLOCKED |
+| write_web_app: path traversal in site_name (`../escape`) | BLOCKED |
+| Content size limit (>1MB rejected) | ENFORCED |
+
+**All path traversal and size limit protections working correctly.**
+
+---
+
+## Bug Fixed During Review
+
+**$-pattern corruption in edit_web_app** (commit `7a0fc11`): `String.prototype.replace()` interprets `$&`, `$$`, `$1` as special replacement patterns. If `new_text` contained `$` characters, the output would be silently corrupted. Fixed by replacing `content.replace(old, new)` with `split(old)` + string concatenation, which treats replacement text literally. Verified with QA test using `$100 $& $$ $1` as replacement text.
+
+---
+
+## Known Limitations
+
+1. **Empty new_text in edit_web_app**: `requireString` validation rejects empty strings, so `edit_web_app` cannot be used to delete text by replacing with `""`. Use `write_web_app` instead.
+2. **deploy_web_apps**: Not tested end-to-end (requires real SWA CLI + deployment token). Dashboard index.html generation is verified.
+3. **Concurrent edits**: No locking mechanism -- concurrent `edit_web_app` calls to the same file could race. Acceptable for single-user bot context.


### PR DESCRIPTION
## Summary

- **`edit_web_app`** — find-and-replace tool for surgical edits to web app files. Validates exact-once match, returns context snippet. Solves the token-limit problem when editing large files (600+ lines).
- **`create_web_app`** — scaffolds new sites with `index.html`, `styles.css`, `app.js`. Hard errors on name collision so Claude picks a unique name.
- **Dashboard upgrade** — deploy landing page upgraded from plain link list to responsive card grid with file counts and sizes.
- **System prompt** updated to guide Claude toward `create_web_app` for new sites and `edit_web_app` for changes.

## Test plan

- [x] 15 new tests added (8 for edit_web_app, 6 for create_web_app, 1 for dashboard)
- [x] All 1027 tests passing
- [x] Lint clean (biome check, 128 files)
- [ ] Manual test: run bot in mock mode, ask it to create a website and then edit it

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)